### PR TITLE
feat: generic `--container-dump` bridge for non-Symfony frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Like the legendary assistant, `igor` checks every connection and part of your ap
 - **🔇 Zero Noise**: Automatically ignores `Symfony\` and `Doctrine\` namespaces, and common data folders (`Entity`, `Dto`, `ApiResource`).
 - **📦 Project vs. Vendor**: Clear separation between your code and third-party dependencies, with tailored recommendations for each.
 - **🎯 Selective Ignore**: Skip specific lines using the `// @igor-ignore` comment, or target entire classes, methods, and properties using modern **PHP 8 Attributes** (`#[WorkerSafe]`).
+- **🌉 Framework-Agnostic Bridge**: Not on Symfony? Feed Igor your container's service graph via `--container-dump <file.json>` so it skips transient (non-shared) value objects and per-request helpers — the same precision the Symfony bridge gives, for **any** framework (Laravel, Laminas, waffle-commons, …).
 
 ---
 
@@ -118,6 +119,32 @@ When using Igor without Symfony, you should manually define which directories or
 
 > 💡 **Note**: Without Symfony, Igor performs a recursive scan of your project directory (excluding folders in `exclude`). Using `scan_vendors` allows you to force the audit of specific third-party libraries even without the Symfony service map.
 
+### 🌉 Generic Container Bridge (`--container-dump`)
+
+Frameworks with their **own DI container** can give Igor the same signal the Symfony bridge provides: which classes are real **shared services** versus **transient** ones (per-request value objects, per-resolution helpers). Without it, a plain directory scan flags legitimate mutators on immutable-by-design value objects (PSR-7 `Uri`/`Stream`/`Message`, PSR-6 `CacheItem`, …) as state leaks.
+
+Export your container's graph to a framework-agnostic JSON file and pass it with `--container-dump`:
+
+```json
+{
+  "services": [
+    { "class": "Waffle\\Commons\\Http\\Uri",          "shared": false },
+    { "class": "Waffle\\Commons\\Cache\\CacheItem",   "shared": false },
+    { "class": "App\\Service\\MailService",  "shared": true }
+  ]
+}
+```
+
+```bash
+igor-php --no-agent --container-dump igor-container.json .
+```
+
+By convention, keep `igor-container.json` at the project root, side-by-side with `igor.json`. Any class listed with `"shared": false` is treated as transient and its state mutations are **skipped** — exactly as the Symfony bridge already skips non-shared (prototype) services. Classes marked `"shared": true`, or absent from the file, continue to be audited normally. You can also set the path in `igor.json` via `"container_dump": "igor-container.json"`.
+
+> 💡 The format is intentionally minimal so **any** framework can produce it (Laravel, Laminas, waffle-commons, …). Symfony's `igor_service_map.json` is simply one richer producer of the same idea.
+>
+> If you **generate** this file from a framework command rather than committing it, a gitignored build path (e.g. `var/igor-container.json`) is also fine — just regenerate it in CI before running Igor, the same way the Symfony agent map is warmed up.
+
 ## 🧪 See it in Action
 
 Want to understand why Igor is vital for your Worker environment? Check these real-world scenarios from our **Leak Lab**:
@@ -191,34 +218,11 @@ You can customize Igor's behavior by creating an `igor.json` file at the root of
 
 ```json
 {
-  "exclude": ["vendor", "var", "src/Entity"],
-  "safe_namespaces": ["Symfony\\", "Doctrine\\", "Twig\\", "IgorPhp\\IgorBundle\\"],
-  "console_path": "bin/console",
-  "env": "dev",
-  "verbose": false
-}
-```
-Time taken: 1.2s
-
-💡 RECOMMENDATIONS:
-  [PROJECT] Since this is your code, you should refactor these services to be stateless
-            or implement ResetInterface to clear the state between requests.
-  [VENDOR]  This is third-party code. If you can't fix it, consider setting a 'max_requests' limit
-            in your Worker configuration to mitigate memory leaks.
-```
-
----
-
-## ⚙️ Configuration
-
-You can customize Igor's behavior by creating an `igor.json` file at the root of your project:
-
-```json
-{
   "exclude": ["vendor", "tests", "Entity"],
   "safe_namespaces": ["Symfony\\", "Doctrine\\", "IgorPhp\\IgorBundle\\"],
   "scan_vendors": ["my-company/internal-bundle"],
   "baseline": "igor-baseline.json",
+  "container_dump": "igor-container.json",
   "console_path": "bin/console",
   "env": "dev",
   "verbose": false
@@ -229,9 +233,16 @@ You can customize Igor's behavior by creating an `igor.json` file at the root of
 - **safe_namespaces**: Igor will ignore state mutations in classes starting with these prefixes.
 - **scan_vendors**: List of sub-directories within `vendor/` to scan recursively.
 - **baseline**: Path to a baseline file containing findings to ignore.
+- **container_dump**: Path to a generic container dump JSON (`{ "services": [ { "class": ..., "shared": bool } ] }`) listing non-shared/transient classes to skip. Equivalent to the `--container-dump` flag.
 - **console_path**: Custom path to the Symfony console binary. Defaults to `bin/console`.
 - **env**: Symfony environment to use for container analysis. Defaults to `dev`.
 - **verbose**: Enable verbose output to see skipped services and reasons. Defaults to `false`.
+
+💡 RECOMMENDATIONS:
+  [PROJECT] Since this is your code, you should refactor these services to be stateless
+  or implement ResetInterface to clear the state between requests.
+  [VENDOR]  This is third-party code. If you can't fix it, consider setting a 'max_requests' limit
+  in your Worker configuration to mitigate memory leaks.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Like the legendary assistant, `igor` checks every connection and part of your ap
 - **🔇 Zero Noise**: Automatically ignores `Symfony\` and `Doctrine\` namespaces, and common data folders (`Entity`, `Dto`, `ApiResource`).
 - **📦 Project vs. Vendor**: Clear separation between your code and third-party dependencies, with tailored recommendations for each.
 - **🎯 Selective Ignore**: Skip specific lines using the `// @igor-ignore` comment, or target entire classes, methods, and properties using modern **PHP 8 Attributes** (`#[WorkerSafe]`).
-- **🌉 Framework-Agnostic Bridge**: Not on Symfony? Feed Igor your container's service graph via `--container-dump <file.json>` so it skips transient (non-shared) value objects and per-request helpers — the same precision the Symfony bridge gives, for **any** framework (Laravel, Laminas, waffle-commons, …).
+- **🌉 Framework-Agnostic Bridge**: Not on Symfony? Feed Igor your container's service graph via `--container-dump <file.json>` so it skips transient (non-shared) value objects and per-request helpers — the same precision the Symfony bridge gives, for **any** framework (Laravel, Laminas, …).
 
 ---
 
@@ -128,9 +128,9 @@ Export your container's graph to a framework-agnostic JSON file and pass it with
 ```json
 {
   "services": [
-    { "class": "Waffle\\Commons\\Http\\Uri",          "shared": false },
-    { "class": "Waffle\\Commons\\Cache\\CacheItem",   "shared": false },
-    { "class": "App\\Service\\MailService",  "shared": true }
+    { "class": "App\\Http\\Uri", "shared": false },
+    { "class": "App\\Cache\\CacheItem", "shared": false },
+    { "class": "App\\Service\\MailService", "shared": true }
   ]
 }
 ```
@@ -141,9 +141,19 @@ igor-php --no-agent --container-dump igor-container.json .
 
 By convention, keep `igor-container.json` at the project root, side-by-side with `igor.json`. Any class listed with `"shared": false` is treated as transient and its state mutations are **skipped** — exactly as the Symfony bridge already skips non-shared (prototype) services. Classes marked `"shared": true`, or absent from the file, continue to be audited normally. You can also set the path in `igor.json` via `"container_dump": "igor-container.json"`.
 
-> 💡 The format is intentionally minimal so **any** framework can produce it (Laravel, Laminas, waffle-commons, …). Symfony's `igor_service_map.json` is simply one richer producer of the same idea.
+> 💡 The format is intentionally minimal so **any** framework can produce it (Laravel, Laminas, …). Symfony's `igor_service_map.json` is simply one richer producer of the same idea.
 >
 > If you **generate** this file from a framework command rather than committing it, a gitignored build path (e.g. `var/igor-container.json`) is also fine — just regenerate it in CI before running Igor, the same way the Symfony agent map is warmed up.
+
+## 🌉 Community Bridges
+
+Igor's core stays framework-agnostic — the Symfony bundle and the generic `--container-dump` contract are all the engine needs. Anyone can ship a thin **bridge** that produces that signal for their own framework. Community-maintained bridges:
+
+| Framework | Bridge | Notes |
+|-----------|--------|-------|
+| **Waffle** | [waffle-commons](https://github.com/waffle-commons) | Emits a `--container-dump` service map and adopts Igor's `#[WorkerSafe]` attribute for FrankenPHP worker-mode state audits. |
+
+> Maintain a bridge for another framework? Open a PR adding a row — the only contract is the `--container-dump` JSON shape shown above.
 
 ## 🧪 See it in Action
 

--- a/cmd/igor/demo_leak_integration_test.go
+++ b/cmd/igor/demo_leak_integration_test.go
@@ -65,6 +65,7 @@ func TestDemoLeakFeatures(t *testing.T) {
 	})
 
 	t.Run("Agent Detection in demo-leak", func(t *testing.T) {
+		requirePHP(t) // LoadContainer locates files via PHP reflection
 		// 1. Mock Agent Map
 		cacheDir := filepath.Join(root, "var", "cache", "dev")
 		if err := os.MkdirAll(cacheDir, 0755); err != nil {

--- a/cmd/igor/integration_test.go
+++ b/cmd/igor/integration_test.go
@@ -78,6 +78,7 @@ func TestSymfonyIntegration(t *testing.T) {
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	t.Run("Bridge should load container and LOCATE files via Reflection", func(t *testing.T) {
+		requirePHP(t)
 		bridge := auditor.NewSymfonyBridge(tmpDir, "bin/console", config.Config{NoAgent: true})
 		err := bridge.LoadContainer("prod")
 		if err != nil {
@@ -102,6 +103,7 @@ func TestSymfonyIntegration(t *testing.T) {
 	})
 
 	t.Run("Bridge should support custom console path", func(t *testing.T) {
+		requirePHP(t)
 		customBinDir := filepath.Join(tmpDir, "app")
 		if err := os.MkdirAll(customBinDir, 0755); err != nil {
 			t.Fatal(err)
@@ -133,6 +135,7 @@ func TestSymfonyIntegration(t *testing.T) {
 	})
 
 	t.Run("Bridge should prioritize Igor Agent service map", func(t *testing.T) {
+		requirePHP(t)
 		cacheDir := filepath.Join(tmpDir, "var", "cache", "test")
 		if err := os.MkdirAll(cacheDir, 0755); err != nil {
 			t.Fatal(err)

--- a/cmd/igor/main.go
+++ b/cmd/igor/main.go
@@ -9,6 +9,7 @@ import (
         "path/filepath"
         "strings"
         "sync"
+	"github.com/igor-php/igor-php/internal/analyzer"
 	"github.com/igor-php/igor-php/internal/auditor"
 	"github.com/igor-php/igor-php/internal/config"
 	"github.com/igor-php/igor-php/pkg/reporter"
@@ -26,6 +27,9 @@ func main() {
 	// 1. Initialize Components
 	aud := auditor.NewAuditor(cfg)
 	rep := setupReporter(cfg)
+
+	// 1b. Load generic container dump (non-shared/transient classes to skip)
+	aud.NonSharedServices = loadContainerDump(rootPath, cfg)
 
 	// 2. Detect Symfony project
 	aud.Symfony = detectSymfonyProject(rootPath, cfg)
@@ -103,6 +107,30 @@ func loadAuditBaseline(rootPath string, cfg config.Config) config.Baseline {
 	return baseline
 }
 
+// loadContainerDump resolves and parses the generic container-dump file (if
+// configured) into the set of non-shared/transient classes whose mutations are
+// safe to skip. Failures are non-fatal: a warning is emitted and the audit
+// proceeds without the bridge signal.
+func loadContainerDump(rootPath string, cfg config.Config) analyzer.NonSharedServiceMap {
+	if cfg.ContainerDump == "" {
+		return nil
+	}
+
+	dumpPath := cfg.ContainerDump
+	if !filepath.IsAbs(dumpPath) {
+		dumpPath = filepath.Join(rootPath, dumpPath)
+	}
+
+	nonShared, err := analyzer.LoadContainerDump(dumpPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "⚠️  Warning: Could not load container dump from %s: %v\n", dumpPath, err)
+		return nil
+	}
+
+	fmt.Fprintf(os.Stderr, "📦 Container dump loaded: %d non-shared (transient) classes will be skipped.\n", len(nonShared))
+	return nonShared
+}
+
 func executeAudit(auditList []symbol.AuditStatus, aud *auditor.Auditor, cfg config.Config, baseline config.Baseline, rootPath string) []symbol.AuditStatus {
 	resultsChan := runParallelAudit(auditList, aud)
 	var finalResults []symbol.AuditStatus
@@ -156,6 +184,7 @@ func parseFlagsAndInit() (config.Config, string, bool) {
 	verboseFlag := flag.Bool("verbose", false, "Enable verbose output to see skipped services and details")
 	noAgentFlag := flag.Bool("no-agent", false, "Disable Igor Agent and fallback to standard scan")
 	outputFlag := flag.String("output", "cli", "Output format (cli, llm, json)")
+	containerDumpFlag := flag.String("container-dump", "", "Path to a generic container dump JSON ({\"services\":[{\"class\":...,\"shared\":bool}]}) used to skip transient (non-shared) classes")
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "🧟 Igor-PHP v%s - The faithful assistant for FrankenPHP Workers\n\n", Version)
@@ -168,6 +197,7 @@ func parseFlagsAndInit() (config.Config, string, bool) {
 		fmt.Fprintf(os.Stderr, "\nExamples:\n")
 		fmt.Fprintf(os.Stderr, "  igor-php .\n")
 		fmt.Fprintf(os.Stderr, "  igor-php --output json .\n")
+		fmt.Fprintf(os.Stderr, "  igor-php --container-dump igor-container.json .\n")
 		fmt.Fprintf(os.Stderr, "  igor-php --generate-baseline\n")
 		fmt.Fprintf(os.Stderr, "  igor-php -c custom-igor.json .\n")
 		fmt.Fprintf(os.Stderr, "  igor-php init\n")
@@ -201,7 +231,7 @@ func parseFlagsAndInit() (config.Config, string, bool) {
 	rootPath, _ := filepath.Abs(args[0])
 
 	cfg := config.LoadConfig(rootPath, configPath)
-	applyFlagOverrides(&cfg, consoleFlag, envFlag, verboseFlag, noAgentFlag, outputFlag, generateBaselineFlag, baselineFlag)
+	applyFlagOverrides(&cfg, consoleFlag, envFlag, verboseFlag, noAgentFlag, outputFlag, generateBaselineFlag, baselineFlag, containerDumpFlag)
 
 	// Display summary of packages
 	if len(cfg.ProdPackages) > 0 || len(cfg.DevPackages) > 0 {
@@ -344,9 +374,12 @@ func handleAPIReview(content string, cfg config.Config) {
 	os.Exit(0)
 }
 
-func applyFlagOverrides(cfg *config.Config, consoleFlag, envFlag *string, verboseFlag, noAgentFlag *bool, outputFlag *string, generateBaselineFlag *bool, baselineFlag *string) {
+func applyFlagOverrides(cfg *config.Config, consoleFlag, envFlag *string, verboseFlag, noAgentFlag *bool, outputFlag *string, generateBaselineFlag *bool, baselineFlag, containerDumpFlag *string) {
 	if *consoleFlag != "" {
 		cfg.ConsolePath = *consoleFlag
+	}
+	if *containerDumpFlag != "" {
+		cfg.ContainerDump = *containerDumpFlag
 	}
 	if *envFlag != "" {
 		cfg.Env = *envFlag

--- a/cmd/igor/main.go
+++ b/cmd/igor/main.go
@@ -437,7 +437,9 @@ func collectFiles(rootPath string, cfg config.Config, aud *auditor.Auditor) []sy
 	processedFiles := make(map[string]bool)
 
 	// --- STEP 1: Add shared services from Symfony (to get IDs and Dependencies) ---
-	if aud.Symfony != nil {
+	// Guard the Container too: a non-nil bridge can still carry a nil Container if
+	// LoadContainer failed, and collectSymfonyServices iterates Container.Definitions.
+	if aud.Symfony != nil && aud.Symfony.Container != nil {
 	        fmt.Fprintln(os.Stderr, "🎯 Symfony detected: Mapping services and dependencies...")
 	        auditList = append(auditList, collectSymfonyServices(rootPath, cfg, aud, processedFiles)...)
 	}

--- a/cmd/igor/php_wrapper_test.go
+++ b/cmd/igor/php_wrapper_test.go
@@ -5,7 +5,19 @@ import (
 	"testing"
 )
 
+// requirePHP skips the test when no `php` binary is on PATH. Igor's PHP-dependent
+// paths (Symfony container introspection, reflection-based file location, `php -l`
+// syntax checks) can only run where PHP is installed — e.g. inside the waffle-dev
+// container — so on a PHP-less host these tests skip rather than fail.
+func requirePHP(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("php"); err != nil {
+		t.Skip("skipping: `php` not found in PATH (run PHP-dependent tests inside waffle-dev)")
+	}
+}
+
 func TestPhpWrapperSyntax(t *testing.T) {
+	requirePHP(t)
 	cmd := exec.Command("php", "-l", "../../internal/auditor/find_class_files.php")
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/cmd/igor/php_wrapper_test.go
+++ b/cmd/igor/php_wrapper_test.go
@@ -7,12 +7,12 @@ import (
 
 // requirePHP skips the test when no `php` binary is on PATH. Igor's PHP-dependent
 // paths (Symfony container introspection, reflection-based file location, `php -l`
-// syntax checks) can only run where PHP is installed — e.g. inside the waffle-dev
-// container — so on a PHP-less host these tests skip rather than fail.
+// syntax checks) can only run where PHP is installed — e.g. inside a container
+// with PHP — so on a PHP-less host these tests skip rather than fail.
 func requirePHP(t *testing.T) {
 	t.Helper()
 	if _, err := exec.LookPath("php"); err != nil {
-		t.Skip("skipping: `php` not found in PATH (run PHP-dependent tests inside waffle-dev)")
+		t.Skip("skipping: `php` not found in PATH (run PHP-dependent tests in a PHP-enabled environment)")
 	}
 }
 

--- a/cmd/igor/verbose_test.go
+++ b/cmd/igor/verbose_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestVerboseOutput(t *testing.T) {
+	requirePHP(t) // LoadContainer shells out to `php`; without it the container stays nil
 	// 1. Setup mock Symfony project
 	tmpDir, _ := os.MkdirTemp("", "igor_verbose_test")
 	defer func() { _ = os.RemoveAll(tmpDir) }()

--- a/internal/analyzer/container.go
+++ b/internal/analyzer/container.go
@@ -1,0 +1,71 @@
+package analyzer
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+)
+
+// ServiceDefinition maps the JSON representation of an individual service.
+//
+// It is a framework-agnostic shape: any container (Symfony, Laravel, Laminas,
+// waffle-commons, …) can emit `{ "class": "...", "shared": bool }` entries so
+// Igor knows which classes are real shared services and which are transient
+// (per-request / per-resolution) value objects that must never be flagged.
+type ServiceDefinition struct {
+	Class  string `json:"class"`
+	Shared bool   `json:"shared"`
+}
+
+// ContainerDump is the root structure of the JSON payload accepted by the
+// `--container-dump` flag, mirroring `{ "services": [ ... ] }`.
+type ContainerDump struct {
+	Services []ServiceDefinition `json:"services"`
+}
+
+// NonSharedServiceMap acts as an O(1) lookup table for transient classes,
+// keyed by fully-qualified class name (without a leading backslash).
+type NonSharedServiceMap map[string]bool
+
+// LoadContainerDump reads and decodes the JSON file, returning a populated map
+// of non-shared (transient) classes.
+//
+// An empty filePath yields an empty (non-nil) map and no error, so callers can
+// invoke it unconditionally. Class names are normalized by trimming any leading
+// namespace separator so lookups match the visitor's resolved FQCN.
+func LoadContainerDump(filePath string) (NonSharedServiceMap, error) {
+	nonSharedMap := make(NonSharedServiceMap)
+
+	if filePath == "" {
+		return nonSharedMap, nil
+	}
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = file.Close() }()
+
+	bytes, err := io.ReadAll(file)
+	if err != nil {
+		return nil, err
+	}
+
+	var dump ContainerDump
+	if err := json.Unmarshal(bytes, &dump); err != nil {
+		return nil, err
+	}
+
+	for _, service := range dump.Services {
+		class := strings.TrimPrefix(service.Class, "\\")
+		if class == "" {
+			continue
+		}
+		if !service.Shared {
+			nonSharedMap[class] = true
+		}
+	}
+
+	return nonSharedMap, nil
+}

--- a/internal/analyzer/container.go
+++ b/internal/analyzer/container.go
@@ -10,9 +10,9 @@ import (
 // ServiceDefinition maps the JSON representation of an individual service.
 //
 // It is a framework-agnostic shape: any container (Symfony, Laravel, Laminas,
-// waffle-commons, …) can emit `{ "class": "...", "shared": bool }` entries so
-// Igor knows which classes are real shared services and which are transient
-// (per-request / per-resolution) value objects that must never be flagged.
+// …) can emit `{ "class": "...", "shared": bool }` entries so Igor knows which
+// classes are real shared services and which are transient (per-request /
+// per-resolution) value objects that must never be flagged.
 type ServiceDefinition struct {
 	Class  string `json:"class"`
 	Shared bool   `json:"shared"`

--- a/internal/analyzer/container_test.go
+++ b/internal/analyzer/container_test.go
@@ -1,0 +1,222 @@
+package analyzer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+	php "github.com/tree-sitter/tree-sitter-php/bindings/go"
+)
+
+func TestLoadContainerDumpValidatesSuccessfully(t *testing.T) {
+	tempFile, err := os.CreateTemp("", "container_test_*.json")
+	if err != nil {
+		t.Fatalf("Failed to create temporary file: %v", err)
+	}
+	defer os.Remove(tempFile.Name())
+
+	content := `{
+        "services": [
+            {"class": "Waffle\\Commons\\Http\\Uri", "shared": false},
+            {"class": "Waffle\\Commons\\Security\\Security", "shared": true}
+        ]
+    }`
+
+	if _, err := tempFile.Write([]byte(content)); err != nil {
+		t.Fatalf("Failed to write mock JSON content: %v", err)
+	}
+	tempFile.Close()
+
+	nonShared, err := LoadContainerDump(tempFile.Name())
+	if err != nil {
+		t.Fatalf("Unexpected parsing error: %v", err)
+	}
+
+	if !nonShared["Waffle\\Commons\\Http\\Uri"] {
+		t.Error("Uri should have been identified as non-shared")
+	}
+
+	if nonShared["Waffle\\Commons\\Security\\Security"] {
+		t.Error("Security is a shared service and should not exist in the non-shared lookup map")
+	}
+}
+
+// TestLoadContainerDumpEmptyPath guarantees callers can invoke the loader
+// unconditionally: an empty path yields an empty, non-nil map and no error.
+func TestLoadContainerDumpEmptyPath(t *testing.T) {
+	nonShared, err := LoadContainerDump("")
+	if err != nil {
+		t.Fatalf("Unexpected error for empty path: %v", err)
+	}
+	if nonShared == nil {
+		t.Fatal("Expected a non-nil map for empty path")
+	}
+	if len(nonShared) != 0 {
+		t.Errorf("Expected an empty map for empty path, got %d entries", len(nonShared))
+	}
+}
+
+// TestLoadContainerDumpMissingFile ensures a missing file surfaces as an error
+// rather than silently succeeding.
+func TestLoadContainerDumpMissingFile(t *testing.T) {
+	_, err := LoadContainerDump(filepath.Join(t.TempDir(), "does-not-exist.json"))
+	if err == nil {
+		t.Fatal("Expected an error for a missing container dump file, got nil")
+	}
+}
+
+// TestLoadContainerDumpNormalizesLeadingBackslash ensures FQCNs emitted with a
+// leading namespace separator still match the visitor's resolved class name.
+func TestLoadContainerDumpNormalizesLeadingBackslash(t *testing.T) {
+	tempFile, err := os.CreateTemp("", "container_norm_*.json")
+	if err != nil {
+		t.Fatalf("Failed to create temporary file: %v", err)
+	}
+	defer os.Remove(tempFile.Name())
+
+	content := `{"services": [{"class": "\\Waffle\\Commons\\Http\\Stream", "shared": false}]}`
+	if _, err := tempFile.Write([]byte(content)); err != nil {
+		t.Fatalf("Failed to write mock JSON content: %v", err)
+	}
+	tempFile.Close()
+
+	nonShared, err := LoadContainerDump(tempFile.Name())
+	if err != nil {
+		t.Fatalf("Unexpected parsing error: %v", err)
+	}
+
+	if !nonShared["Waffle\\Commons\\Http\\Stream"] {
+		t.Error("Stream should be matched after trimming the leading backslash")
+	}
+}
+
+// countErrors walks a snippet of PHP and returns how many ERROR findings the
+// visitor produces, optionally seeded with a non-shared service map.
+func countErrors(t *testing.T, code string, nonShared NonSharedServiceMap) int {
+	t.Helper()
+
+	content := []byte(code)
+	p := sitter.NewParser()
+	lang := sitter.NewLanguage(php.LanguagePHP())
+	if err := p.SetLanguage(lang); err != nil {
+		t.Fatalf("failed to set language: %v", err)
+	}
+	tree := p.Parse(content, nil)
+	defer tree.Close()
+
+	v := NewVisitor(content, &mockEngine{})
+	v.SetNonSharedServices(nonShared)
+	v.Walk(tree.RootNode())
+
+	errors := 0
+	for _, f := range v.Findings() {
+		if f.Severity == "ERROR" {
+			errors++
+		}
+	}
+	return errors
+}
+
+// TestNonSharedServiceBypassSuppressesMutation reproduces the report's
+// categories 3 & 4: a per-request value object whose legitimate mutator is
+// flagged as KO. When the class is declared non-shared via the container dump,
+// the mutation must be skipped.
+func TestNonSharedServiceBypassSuppressesMutation(t *testing.T) {
+	code := `<?php
+namespace Waffle\Commons\Http;
+
+final class Uri
+{
+    private string $scheme = '';
+    public function set(string $v): void
+    {
+        $this->scheme = $v;
+    }
+}`
+
+	// Control: without the bridge signal, the mutation is reported as KO.
+	if got := countErrors(t, code, nil); got == 0 {
+		t.Fatal("expected a KO finding for the mutation without the container dump")
+	}
+
+	// With the dump declaring Waffle\Http\Uri as non-shared, it is skipped.
+	nonShared := NonSharedServiceMap{"Waffle\\Commons\\Http\\Uri": true}
+	if got := countErrors(t, code, nonShared); got != 0 {
+		t.Errorf("expected 0 findings for a non-shared transient class, got %d", got)
+	}
+}
+
+// TestNonSharedServiceBypassStillFlagsSharedClass ensures the bypass is scoped:
+// a class that is NOT in the non-shared map keeps being audited normally.
+func TestNonSharedServiceBypassStillFlagsSharedClass(t *testing.T) {
+	code := `<?php
+namespace Waffle\Commons\Security;
+
+final class Security
+{
+    private string $token = '';
+    public function set(string $v): void
+    {
+        $this->token = $v;
+    }
+}`
+
+	// Map contains a different class; Security must still be flagged.
+	nonShared := NonSharedServiceMap{"Waffle\\Commons\\Http\\Uri": true}
+	if got := countErrors(t, code, nonShared); got == 0 {
+		t.Error("expected a KO finding for a shared class absent from the non-shared map")
+	}
+}
+
+// TestNonSharedServiceBypassIsNoOpWhenUnset proves the feature is fully
+// optional: whether the container dump is never configured (the map field stays
+// nil), explicitly nil, or an empty non-nil map, the visitor audits mutations
+// identically to how it behaved before the feature existed — and reading a nil
+// map must never panic.
+func TestNonSharedServiceBypassIsNoOpWhenUnset(t *testing.T) {
+	code := `<?php
+namespace App\Service;
+
+final class StatefulService
+{
+    private string $token = '';
+    public function set(string $v): void
+    {
+        $this->token = $v;
+    }
+}`
+
+	// Baseline: a visitor whose SetNonSharedServices is never called, so the
+	// nonSharedServices field keeps its zero value (nil map). This is exactly the
+	// "no --container-dump configured" production path.
+	content := []byte(code)
+	p := sitter.NewParser()
+	if err := p.SetLanguage(sitter.NewLanguage(php.LanguagePHP())); err != nil {
+		t.Fatalf("failed to set language: %v", err)
+	}
+	tree := p.Parse(content, nil)
+	defer tree.Close()
+
+	v := NewVisitor(content, &mockEngine{}) // SetNonSharedServices intentionally NOT called
+	v.Walk(tree.RootNode())                 // must not panic reading the nil map
+
+	unset := 0
+	for _, f := range v.Findings() {
+		if f.Severity == "ERROR" {
+			unset++
+		}
+	}
+	if unset == 0 {
+		t.Fatal("expected the mutation to be flagged when no container dump is configured (nil map must be a no-op)")
+	}
+
+	// An explicit nil map and an empty (non-nil) map must yield the identical
+	// result — the bridge can only ever suppress findings for classes it lists.
+	if got := countErrors(t, code, nil); got != unset {
+		t.Errorf("explicit nil map changed results: got %d, want %d (no-op expected)", got, unset)
+	}
+	if got := countErrors(t, code, NonSharedServiceMap{}); got != unset {
+		t.Errorf("empty map changed results: got %d, want %d (no-op expected)", got, unset)
+	}
+}

--- a/internal/analyzer/container_test.go
+++ b/internal/analyzer/container_test.go
@@ -18,8 +18,8 @@ func TestLoadContainerDumpValidatesSuccessfully(t *testing.T) {
 
 	content := `{
         "services": [
-            {"class": "Waffle\\Commons\\Http\\Uri", "shared": false},
-            {"class": "Waffle\\Commons\\Security\\Security", "shared": true}
+            {"class": "App\\Http\\Uri", "shared": false},
+            {"class": "App\\Security\\Security", "shared": true}
         ]
     }`
 
@@ -33,11 +33,11 @@ func TestLoadContainerDumpValidatesSuccessfully(t *testing.T) {
 		t.Fatalf("Unexpected parsing error: %v", err)
 	}
 
-	if !nonShared["Waffle\\Commons\\Http\\Uri"] {
+	if !nonShared["App\\Http\\Uri"] {
 		t.Error("Uri should have been identified as non-shared")
 	}
 
-	if nonShared["Waffle\\Commons\\Security\\Security"] {
+	if nonShared["App\\Security\\Security"] {
 		t.Error("Security is a shared service and should not exist in the non-shared lookup map")
 	}
 }
@@ -75,7 +75,7 @@ func TestLoadContainerDumpNormalizesLeadingBackslash(t *testing.T) {
 	}
 	defer os.Remove(tempFile.Name())
 
-	content := `{"services": [{"class": "\\Waffle\\Commons\\Http\\Stream", "shared": false}]}`
+	content := `{"services": [{"class": "\\App\\Http\\Stream", "shared": false}]}`
 	if _, err := tempFile.Write([]byte(content)); err != nil {
 		t.Fatalf("Failed to write mock JSON content: %v", err)
 	}
@@ -86,7 +86,7 @@ func TestLoadContainerDumpNormalizesLeadingBackslash(t *testing.T) {
 		t.Fatalf("Unexpected parsing error: %v", err)
 	}
 
-	if !nonShared["Waffle\\Commons\\Http\\Stream"] {
+	if !nonShared["App\\Http\\Stream"] {
 		t.Error("Stream should be matched after trimming the leading backslash")
 	}
 }
@@ -124,7 +124,7 @@ func countErrors(t *testing.T, code string, nonShared NonSharedServiceMap) int {
 // the mutation must be skipped.
 func TestNonSharedServiceBypassSuppressesMutation(t *testing.T) {
 	code := `<?php
-namespace Waffle\Commons\Http;
+namespace App\Http;
 
 final class Uri
 {
@@ -140,8 +140,8 @@ final class Uri
 		t.Fatal("expected a KO finding for the mutation without the container dump")
 	}
 
-	// With the dump declaring Waffle\Http\Uri as non-shared, it is skipped.
-	nonShared := NonSharedServiceMap{"Waffle\\Commons\\Http\\Uri": true}
+	// With the dump declaring App\Http\Uri as non-shared, it is skipped.
+	nonShared := NonSharedServiceMap{"App\\Http\\Uri": true}
 	if got := countErrors(t, code, nonShared); got != 0 {
 		t.Errorf("expected 0 findings for a non-shared transient class, got %d", got)
 	}
@@ -151,7 +151,7 @@ final class Uri
 // a class that is NOT in the non-shared map keeps being audited normally.
 func TestNonSharedServiceBypassStillFlagsSharedClass(t *testing.T) {
 	code := `<?php
-namespace Waffle\Commons\Security;
+namespace App\Security;
 
 final class Security
 {
@@ -163,7 +163,7 @@ final class Security
 }`
 
 	// Map contains a different class; Security must still be flagged.
-	nonShared := NonSharedServiceMap{"Waffle\\Commons\\Http\\Uri": true}
+	nonShared := NonSharedServiceMap{"App\\Http\\Uri": true}
 	if got := countErrors(t, code, nonShared); got == 0 {
 		t.Error("expected a KO finding for a shared class absent from the non-shared map")
 	}

--- a/internal/analyzer/container_test.go
+++ b/internal/analyzer/container_test.go
@@ -14,7 +14,7 @@ func TestLoadContainerDumpValidatesSuccessfully(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temporary file: %v", err)
 	}
-	defer os.Remove(tempFile.Name())
+	defer func() { _ = os.Remove(tempFile.Name()) }()
 
 	content := `{
         "services": [
@@ -26,7 +26,7 @@ func TestLoadContainerDumpValidatesSuccessfully(t *testing.T) {
 	if _, err := tempFile.Write([]byte(content)); err != nil {
 		t.Fatalf("Failed to write mock JSON content: %v", err)
 	}
-	tempFile.Close()
+	_ = tempFile.Close()
 
 	nonShared, err := LoadContainerDump(tempFile.Name())
 	if err != nil {
@@ -73,13 +73,13 @@ func TestLoadContainerDumpNormalizesLeadingBackslash(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temporary file: %v", err)
 	}
-	defer os.Remove(tempFile.Name())
+	defer func() { _ = os.Remove(tempFile.Name()) }()
 
 	content := `{"services": [{"class": "\\App\\Http\\Stream", "shared": false}]}`
 	if _, err := tempFile.Write([]byte(content)); err != nil {
 		t.Fatalf("Failed to write mock JSON content: %v", err)
 	}
-	tempFile.Close()
+	_ = tempFile.Close()
 
 	nonShared, err := LoadContainerDump(tempFile.Name())
 	if err != nil {

--- a/internal/analyzer/visitor.go
+++ b/internal/analyzer/visitor.go
@@ -40,6 +40,7 @@ type PHPVisitor struct {
 	resetted           map[string]bool
 	engine             Engine
 	dependencies       []string
+	nonSharedServices  NonSharedServiceMap
 }
 
 // NewVisitor creates a new instance of the PHPVisitor.
@@ -57,6 +58,13 @@ func NewVisitor(content []byte, engine Engine) *PHPVisitor {
 
 func (v *PHPVisitor) SetDependencies(deps []string) {
 	v.dependencies = deps
+}
+
+// SetNonSharedServices supplies the generic container-dump lookup of transient
+// (shared: false) classes. Mutations inside such classes are skipped, mirroring
+// the Symfony bridge's IsExplicitlyNonShared() signal for non-Symfony frameworks.
+func (v *PHPVisitor) SetNonSharedServices(m NonSharedServiceMap) {
+	v.nonSharedServices = m
 }
 
 func (v *PHPVisitor) Walk(n *sitter.Node) {
@@ -300,6 +308,12 @@ func (v *PHPVisitor) handleMutation(n *sitter.Node) {
 	fullName := v.curClass
 	if v.namespace != "" {
 		fullName = v.namespace + "\\" + v.curClass
+	}
+
+	// Generic container-dump bypass: the class is registered as a transient
+	// (shared: false) service, so its mutations never outlive a request.
+	if v.nonSharedServices[strings.TrimPrefix(fullName, "\\")] {
+		return
 	}
 
 	if v.engine != nil && (v.engine.IsExplicitlyNonShared(fullName) || v.engine.IsSafeNamespace(fullName)) {

--- a/internal/auditor/auditor.go
+++ b/internal/auditor/auditor.go
@@ -17,10 +17,11 @@ import (
 
 // Auditor orchestrates the analysis of PHP files.
 type Auditor struct {
-	Config         config.Config
-	Symfony        *SymfonyBridge
-	AuditedClasses map[string]bool
-	mu             sync.Mutex
+	Config            config.Config
+	Symfony           *SymfonyBridge
+	NonSharedServices analyzer.NonSharedServiceMap
+	AuditedClasses    map[string]bool
+	mu                sync.Mutex
 }
 
 // NewAuditor creates a new instance of the Auditor.
@@ -52,6 +53,7 @@ func (a *Auditor) Audit(path string, dependencies []string) ([]symbol.Finding, e
 
 	v := analyzer.NewVisitor(content, a)
 	v.SetDependencies(dependencies)
+	v.SetNonSharedServices(a.NonSharedServices)
 	v.Walk(tree.RootNode())
 
 	return v.Findings(), nil

--- a/internal/config/models.go
+++ b/internal/config/models.go
@@ -14,6 +14,7 @@ type Config struct {
         DevPackages      []string `json:"-"` // List of require-dev packages from composer.json
         GenerateBaseline bool     `json:"-"` // Internal: set if --generate-baseline is used
         OutputFormat     string   `json:"output"`
+        ContainerDump    string   `json:"container_dump"` // Path to a generic container dump (framework-agnostic non-shared service graph)
         LLMConfig        LLMConfig `json:"llm"`
 }
 


### PR DESCRIPTION
# feat: generic `--container-dump` bridge for non-Symfony frameworks

## Summary

Adds a framework-agnostic `--container-dump <file.json>` flag so projects with
their **own DI container** can give Igor the same signal the Symfony bridge
provides: which classes are real **shared services** versus **transient**
(per-request value objects, per-resolution helpers). Transient classes
(`"shared": false`) are skipped during state-mutation analysis.

This implements a **generic flavor** from the false-positives report
on non-Symfony projects: per-request value objects (PSR-7 `Uri`/`Stream`/
`Message`, PSR-6 `CacheItem`) and transient helpers were being audited as if
they were shared services and flagged as `❌ KO`, even though they never leak
state between requests. The path of least resistance for those users today is a
broad baseline suppression — which defeats the purpose of the tool. This flag
removes the false positives **with zero annotations**.

Resolves report categories **3 (per-request value objects)** and
**4 (transient per-resolution helpers)**.

## Commits

The branch is intentionally split into three reviewable commits:

| Commit | Type | Scope |
|--------|------|-------|
| `feat(container)` | feature | The generic container-dump parser, flag, visitor bypass, wiring, tests, and docs. |
| `fix(cli)` | bug fix | Guards `collectFiles` against a non-nil Symfony bridge that carries a nil `Container` (nil-pointer panic). Independent of the feature. |
| `test(cli)` | tests | Skips PHP-dependent `cmd/igor` tests when `php` is not on `PATH`, so the suite is green on PHP-less hosts and still runs in CI / a container. |

The `fix` and `test` commits surfaced while validating the feature against the
full suite; they are kept separate so they can be reviewed (or taken upstream)
on their own merits.

## What changed (feature)

| File | Change |
|------|--------|
| `internal/analyzer/container.go` *(new)* | Framework-agnostic parser: `ContainerDump` / `ServiceDefinition` types + `LoadContainerDump()` building an O(1) `NonSharedServiceMap` of `shared: false` classes. |
| `internal/analyzer/visitor.go` | `PHPVisitor` gains a `nonSharedServices` field + `SetNonSharedServices()`; `handleMutation()` skips mutations for classes in the map. |
| `internal/auditor/auditor.go` | `Auditor` holds the map and passes it to each per-file visitor. |
| `internal/config/models.go` | New `container_dump` config field (works via `igor.json` too). |
| `cmd/igor/main.go` | Registers the `--container-dump` flag, loads the dump once at boot (warn-but-continue on error), wires it onto the auditor. |
| `internal/analyzer/container_test.go` *(new)* | Loader unit tests + visitor-level tests proving the bypass and the no-op (unset) path. |
| `README.md` | Documents the bridge, JSON format, CLI usage, and `container_dump` config. |

## Design

The visitor already exposed an `Engine.IsExplicitlyNonShared()` gate that
`handleMutation()` consulted to skip Symfony non-shared services. Rather than
adding a parallel mechanism, the generic dump feeds the **same gate** for
non-Symfony frameworks. The Symfony bridge stays untouched and becomes one
producer of the format rather than a special case.

The JSON shape is intentionally minimal so any framework (Laravel, Laminas, …) 
can emit it:

```json
{
  "services": [
    { "class": "App\\Http\\Uri",                     "shared": false },
    { "class": "App\\Service\\MailService",          "shared": true }
  ]
}
```

Class names are normalized (leading `\` trimmed) to match the visitor's
resolved FQCN. An empty/omitted path is a no-op; a missing file warns and the
audit proceeds (consistent with baseline loading). The bridge is **monotonic**:
it can only ever *suppress* findings for classes it explicitly lists — it never
adds findings or changes analysis for any class not in the file.

## The `fix(cli)` commit

`collectFiles` guarded `aud.Symfony != nil` but then iterated
`aud.Symfony.Container.Definitions`, so a bridge whose `LoadContainer` failed
(non-nil bridge, **nil** `Container`) caused a nil-pointer panic that aborted
the whole audit. The guard now also requires a non-nil `Container` before
mapping Symfony services. This is a pre-existing robustness gap, independent of
the container-dump feature.

## The `test(cli)` commit

Several `cmd/igor` tests shell out to `php` (Symfony container introspection,
reflection-based file location, `php -l` syntax checks). On a host without PHP
they failed; they can only run where PHP is installed. A `requirePHP(t)` helper
`t.Skip`s those tests/subtests when `php` is not on `PATH`, leaving the PHP-free
subtests running. Where PHP is present (CI / PHP container) they run unchanged.

## Usage

```bash
igor-php --no-agent --container-dump igor-container.json .
```

By convention, keep `igor-container.json` at the project root, side-by-side with
`igor.json`. **The filename and relative path are completely arbitrary, though 
sticking to this convention is recommended for consistency across projects.** 
You can also set it in config:

```json
{ "container_dump": "igor-container.json" }
```



## Testing

- New `container_test.go` covers: valid parse, empty path, missing file,
  leading-backslash normalization, two visitor-level tests proving a transient
  `App\Http\Uri` mutator goes from `❌ KO` → skipped while a class
  absent from the map is still flagged, and a no-op test proving the feature is
  fully optional (unset/nil/empty map all behave identically and never panic).
- End-to-end verified: without the flag a mutator reports `❌ KO` (exit 1); with
  `--container-dump` the audit is `✅ OK` (exit 0).
- `go vet ./...` clean; **full suite green** (`go test ./...`). PHP-dependent
  tests skip on PHP-less hosts and run normally where PHP is available.

