### PR TITLE
fix: robustly parse reflection mapping by isolating stdout/stderr (#39)

### DIFF
--- a/cmd/igor/integration_test.go
+++ b/cmd/igor/integration_test.go
@@ -102,6 +102,57 @@ func TestSymfonyIntegration(t *testing.T) {
 		}
 	})
 
+	t.Run("Bridge should survive PHP deprecations or warnings during reflection", func(t *testing.T) {
+		requirePHP(t)
+
+		noiseAutoloader := `<?php
+fwrite(STDERR, "PHP Deprecated:  Some deprecated library feature in autoload\n");
+echo "Psr\\Log\\InvalidArgumentException is loaded\n";
+
+spl_autoload_register(function ($class) {
+    if ($class === 'App\\Service\\MyService') {
+        require_once '` + servicePath + `';
+    }
+});
+`
+		if err := os.WriteFile(filepath.Join(tmpDir, "vendor", "autoload.php"), []byte(noiseAutoloader), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		defer func() {
+			originalAutoloader := `<?php
+spl_autoload_register(function ($class) {
+    if ($class === 'App\\Service\\MyService') {
+        require_once '` + servicePath + `';
+    }
+});
+`
+			_ = os.WriteFile(filepath.Join(tmpDir, "vendor", "autoload.php"), []byte(originalAutoloader), 0644);
+		}()
+
+		bridge := auditor.NewSymfonyBridge(tmpDir, "bin/console", config.Config{NoAgent: true})
+		err := bridge.LoadContainer("prod")
+		if err != nil {
+			t.Fatalf("LoadContainer failed with stdout/stderr noise: %v", err)
+		}
+
+		if bridge.Container == nil {
+			t.Fatal("Expected container to be loaded")
+		}
+
+		filePath, found := bridge.ClassToFile["App\\Service\\MyService"]
+		if !found {
+			t.Fatal("Expected App\\Service\\MyService to be located via reflection even with noise")
+		}
+
+		realServicePath, _ := filepath.EvalSymlinks(servicePath)
+		realLocatedPath, _ := filepath.EvalSymlinks(filePath)
+
+		if realLocatedPath != realServicePath {
+			t.Errorf("Expected path %s, got %s", realServicePath, realLocatedPath)
+		}
+	})
+
 	t.Run("Bridge should support custom console path", func(t *testing.T) {
 		requirePHP(t)
 		customBinDir := filepath.Join(tmpDir, "app")

--- a/internal/auditor/find_class_files.php
+++ b/internal/auditor/find_class_files.php
@@ -47,4 +47,4 @@ foreach ($classesToCheck as $class => $_) {
     } catch (Throwable $e) {}
 }
 
-echo json_encode($mapping);
+echo json_encode((object)$mapping);

--- a/internal/auditor/symfony.go
+++ b/internal/auditor/symfony.go
@@ -165,12 +165,29 @@ func (b *SymfonyBridge) locateFilesViaReflection(jsonPart string) error {
 	reflectCmd := exec.Command("php", tmpHelper.Name(), b.Root)
 	reflectCmd.Stdin = bytes.NewReader([]byte(jsonPart))
 
-	reflectOutput, err := reflectCmd.CombinedOutput()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	reflectCmd.Stdout = &stdout
+	reflectCmd.Stderr = &stderr
+
+	err = reflectCmd.Run()
 	if err != nil {
-		return fmt.Errorf("failed to locate files via reflection: %v", err)
+		return fmt.Errorf("failed to locate files via reflection: %v (stderr: %s)", err, stderr.String())
 	}
 
-	if err := json.Unmarshal(reflectOutput, &b.ClassToFile); err != nil {
+	strOutput := stdout.String()
+	start := strings.Index(strOutput, "{")
+	end := strings.LastIndex(strOutput, "}")
+	if start == -1 || end == -1 || end < start {
+		// Fallback to try unmarshaling the entire stdout if no braces found (highly unlikely if it ran successfully)
+		if err := json.Unmarshal(stdout.Bytes(), &b.ClassToFile); err != nil {
+			return fmt.Errorf("failed to parse reflection mapping (no JSON object found in output: %q): %v", strOutput, err)
+		}
+		return nil
+	}
+
+	cleanJson := strOutput[start : end+1]
+	if err := json.Unmarshal([]byte(cleanJson), &b.ClassToFile); err != nil {
 		return fmt.Errorf("failed to parse reflection mapping: %v", err)
 	}
 


### PR DESCRIPTION
Isolate stdout and stderr stream buffers in locateFilesViaReflection to prevent PHP startup warnings, notices, or deprecations on stderr from polluting the JSON payload. Extract only the JSON object between curly braces from stdout, and guarantee that find_class_files.php returns a JSON object even when empty. Add comprehensive integration test.