### PR TITLE
feat: detect state cleanups in finally blocks to prevent false positives

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ During its static analysis of shared/singleton services, Igor recursively scans 
 | :--- | :--- | :--- | :---: | :--- |
 | **Dependency Mutation** | `DetectSingletonMutation` | Calling mutation methods (starting with `set`, `add`, `push`, `register`, `append`) on injected properties. | 🔴 Critical | `$this->googleTagManager->addPush($data);` |
 | **Closure State Leak** | `DetectClosureStateLeak` | Passing anonymous functions that capture local variables (`use ($var)`) to shared service dependencies. | 🔴 Critical | `$this->dispatcher->addListener('response', function () use ($optin) {});` |
+| **Finally Cleanup** | *(Bypass)* | Igor natively detects when a mutated state is guaranteed to be cleaned up inside a `finally` block (using `array_pop`, `unset`, or direct assignments), and **automatically bypasses the error**. | 🟢 Safe (Auto) | `try { $this->stack[] = $item; } finally { array_pop($this->stack); }` |
 | **State Mutation** | `StateMutation` | Direct assignment or mutation of class properties or static variables at runtime. | 🔴 Critical | `$this->count++;`<br>`self::$cache[] = $val;` |
 | **Reset Interface** | `IncompleteReset` | Class implements `ResetInterface` but some of its mutated properties are not cleared inside `reset()`. | 🟡 Warning | `public function reset() {`<br>`  // forgot to clear $count`<br>`}` |
 | **Process State Mutation** | `ProcessStateMutation` | Functions modifying global PHP configuration or runtime behavior that persist across requests. | 🟡 Warning | `date_default_timezone_set('UTC');`<br>`ini_set('memory_limit', '256M');` |
@@ -48,6 +49,9 @@ During its static analysis of shared/singleton services, Igor recursively scans 
 > To achieve this, Igor is deliberately strict: **we chose to report as many potential issues as possible** to guide your eyes to where things might go wrong. Consequently, Igor may occasionally raise false positives. It remains your responsibility to analyze Igor's findings and decide if they can be safely ignored (e.g., using `// @igor-ignore` or the `#[WorkerSafe]` attribute).
 >
 > **Pro-Tip**: Enabling the **Symfony Bundle** dramatically reduces false positives. It grants Igor direct visibility into Symfony's compiled container, allowing it to bypass warnings for transient (non-shared) services and automatically ignore mutations on services marked as resettable (tagged with `kernel.reset`).
+
+> 🧠 **Smart Stack Cleanup (Finally Blocks)**:
+> If your service manages temporary state using a stack or push/pop pattern (like Symfony's `AuthorizationChecker`), Igor is smart enough to scan `finally` clauses. If it detects that a mutated property is guaranteed to be restored or cleaned up inside the `finally` block (using `array_pop()`, `array_shift()`, `unset()`, or direct resets), the mutation is marked as safe and the warning is automatically bypassed.
 
 ---
 

--- a/internal/analyzer/visitor.go
+++ b/internal/analyzer/visitor.go
@@ -99,32 +99,7 @@ func (v *PHPVisitor) walk(n *sitter.Node) {
 		}
 		v.isWorkerSafeMethod = v.hasAttribute(n, "WorkerSafe")
 		v.finallyCleaned = make(map[string]bool)
-
-		// Pre-scan the entire method body for finally cleanups
-		body := n.ChildByFieldName("body")
-		if body != nil {
-			var preScanFinally func(*sitter.Node)
-			preScanFinally = func(node *sitter.Node) {
-				if node == nil {
-					return
-				}
-				if node.Kind() == "try_statement" {
-					for i := uint(0); i < node.ChildCount(); i++ {
-						child := node.Child(i)
-						if child.Kind() == "finally_clause" {
-							cleanups := v.getFinallyCleanedProperties(child)
-							for prop := range cleanups {
-								v.finallyCleaned[prop] = true
-							}
-						}
-					}
-				}
-				for i := uint(0); i < node.ChildCount(); i++ {
-					preScanFinally(node.Child(i))
-				}
-			}
-			preScanFinally(body)
-		}
+		v.preScanFinallyCleanups(n)
 	case "assignment_expression", "augmented_assignment_expression":
 		v.handleMutation(n.ChildByFieldName("left"))
 	case "update_expression":
@@ -790,56 +765,13 @@ func (v *PHPVisitor) getFinallyCleanedProperties(finallyNode *sitter.Node) map[s
 			return
 		}
 
-		// 1. Detect function calls like array_pop($this->propertyName) or array_shift($this->propertyName)
-		if node.Kind() == "function_call_expression" {
-			fnNameNode := node.ChildByFieldName("function")
-			if fnNameNode == nil {
-				fnNameNode = node.ChildByFieldName("name")
-			}
-			if fnNameNode != nil {
-				fnName := strings.ToLower(v.getContent(fnNameNode))
-				if fnName == "array_pop" || fnName == "array_shift" {
-					argsNode := node.ChildByFieldName("arguments")
-					if argsNode != nil {
-						for i := uint(0); i < argsNode.ChildCount(); i++ {
-							arg := argsNode.Child(i)
-							if arg.Kind() == "argument" && arg.NamedChildCount() > 0 {
-								expr := arg.NamedChild(0)
-								if expr != nil && expr.Kind() == "member_access_expression" {
-									prop, isProp := v.isPropertyFetchOnThis(expr)
-									if isProp {
-										cleanups[prop] = true
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-
-		// 2. Detect assignment expressions like $this->propertyName = null or $this->propertyName = []
-		if node.Kind() == "assignment_expression" {
-			left := node.ChildByFieldName("left")
-			if left != nil && left.Kind() == "member_access_expression" {
-				prop, isProp := v.isPropertyFetchOnThis(left)
-				if isProp {
-					cleanups[prop] = true
-				}
-			}
-		}
-
-		// 3. Detect unset statements like unset($this->propertyName)
-		if node.Kind() == "unset_statement" {
-			for i := uint(0); i < node.ChildCount(); i++ {
-				child := node.Child(i)
-				if child.Kind() == "member_access_expression" {
-					prop, isProp := v.isPropertyFetchOnThis(child)
-					if isProp {
-						cleanups[prop] = true
-					}
-				}
-			}
+		switch node.Kind() {
+		case "function_call_expression":
+			v.checkFinallyFunctionCall(node, cleanups)
+		case "assignment_expression":
+			v.checkFinallyAssignment(node, cleanups)
+		case "unset_statement":
+			v.checkFinallyUnset(node, cleanups)
 		}
 
 		for i := uint(0); i < node.ChildCount(); i++ {
@@ -849,4 +781,88 @@ func (v *PHPVisitor) getFinallyCleanedProperties(finallyNode *sitter.Node) map[s
 
 	walkFinally(finallyNode)
 	return cleanups
+}
+
+// checkFinallyFunctionCall detects cleanup function calls like array_pop($this->propertyName) or array_shift($this->propertyName).
+func (v *PHPVisitor) checkFinallyFunctionCall(node *sitter.Node, cleanups map[string]bool) {
+	fnNameNode := node.ChildByFieldName("function")
+	if fnNameNode == nil {
+		fnNameNode = node.ChildByFieldName("name")
+	}
+	if fnNameNode == nil {
+		return
+	}
+	fnName := strings.ToLower(v.getContent(fnNameNode))
+	if fnName != "array_pop" && fnName != "array_shift" {
+		return
+	}
+	argsNode := node.ChildByFieldName("arguments")
+	if argsNode == nil {
+		return
+	}
+	for i := uint(0); i < argsNode.ChildCount(); i++ {
+		arg := argsNode.Child(i)
+		if arg.Kind() == "argument" && arg.NamedChildCount() > 0 {
+			expr := arg.NamedChild(0)
+			if expr != nil && expr.Kind() == "member_access_expression" {
+				prop, isProp := v.isPropertyFetchOnThis(expr)
+				if isProp {
+					cleanups[prop] = true
+				}
+			}
+		}
+	}
+}
+
+// checkFinallyAssignment detects cleanup assignments like $this->propertyName = null or $this->propertyName = [].
+func (v *PHPVisitor) checkFinallyAssignment(node *sitter.Node, cleanups map[string]bool) {
+	left := node.ChildByFieldName("left")
+	if left != nil && left.Kind() == "member_access_expression" {
+		prop, isProp := v.isPropertyFetchOnThis(left)
+		if isProp {
+			cleanups[prop] = true
+		}
+	}
+}
+
+// checkFinallyUnset detects cleanup unset statements like unset($this->propertyName).
+func (v *PHPVisitor) checkFinallyUnset(node *sitter.Node, cleanups map[string]bool) {
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		if child.Kind() == "member_access_expression" {
+			prop, isProp := v.isPropertyFetchOnThis(child)
+			if isProp {
+				cleanups[prop] = true
+			}
+		}
+	}
+}
+
+// preScanFinallyCleanups recursively scans a method or function body to extract properties cleaned up in finally blocks.
+func (v *PHPVisitor) preScanFinallyCleanups(n *sitter.Node) {
+	body := n.ChildByFieldName("body")
+	if body == nil {
+		return
+	}
+	var preScanFinally func(*sitter.Node)
+	preScanFinally = func(node *sitter.Node) {
+		if node == nil {
+			return
+		}
+		if node.Kind() == "try_statement" {
+			for i := uint(0); i < node.ChildCount(); i++ {
+				child := node.Child(i)
+				if child.Kind() == "finally_clause" {
+					cleanups := v.getFinallyCleanedProperties(child)
+					for prop := range cleanups {
+						v.finallyCleaned[prop] = true
+					}
+				}
+			}
+		}
+		for i := uint(0); i < node.ChildCount(); i++ {
+			preScanFinally(node.Child(i))
+		}
+	}
+	preScanFinally(body)
 }

--- a/internal/analyzer/visitor.go
+++ b/internal/analyzer/visitor.go
@@ -38,6 +38,7 @@ type PHPVisitor struct {
 	readonlyProps      map[string]bool
 	workerSafeProps    map[string]bool
 	propertyTypes      map[string]string
+	finallyCleaned     map[string]bool
 	mutated            map[string]mutationInfo
 	resetted           map[string]bool
 	engine             Engine
@@ -55,6 +56,7 @@ func NewVisitor(content []byte, engine Engine) *PHPVisitor {
 		readonlyProps:   make(map[string]bool),
 		workerSafeProps: make(map[string]bool),
 		propertyTypes:   make(map[string]string),
+		finallyCleaned:  make(map[string]bool),
 		engine:          engine,
 	}
 }
@@ -84,7 +86,7 @@ func (v *PHPVisitor) walk(n *sitter.Node) {
 	}
 	nodeType := n.Kind()
 
-	oldClass, oldMethod, oldIsRes, oldIsReadonly, oldReadonlyProps, oldIsWorkerSafeClass, oldIsWorkerSafeMethod := v.curClass, v.curMethod, v.isReset, v.isReadonlyClass, v.readonlyProps, v.isWorkerSafeClass, v.isWorkerSafeMethod
+	oldClass, oldMethod, oldIsRes, oldIsReadonly, oldReadonlyProps, oldIsWorkerSafeClass, oldIsWorkerSafeMethod, oldFinallyCleaned := v.curClass, v.curMethod, v.isReset, v.isReadonlyClass, v.readonlyProps, v.isWorkerSafeClass, v.isWorkerSafeMethod, v.finallyCleaned
 
 	switch nodeType {
 	case "namespace_definition":
@@ -96,6 +98,33 @@ func (v *PHPVisitor) walk(n *sitter.Node) {
 			v.curMethod = v.getContent(nameNode)
 		}
 		v.isWorkerSafeMethod = v.hasAttribute(n, "WorkerSafe")
+		v.finallyCleaned = make(map[string]bool)
+
+		// Pre-scan the entire method body for finally cleanups
+		body := n.ChildByFieldName("body")
+		if body != nil {
+			var preScanFinally func(*sitter.Node)
+			preScanFinally = func(node *sitter.Node) {
+				if node == nil {
+					return
+				}
+				if node.Kind() == "try_statement" {
+					for i := uint(0); i < node.ChildCount(); i++ {
+						child := node.Child(i)
+						if child.Kind() == "finally_clause" {
+							cleanups := v.getFinallyCleanedProperties(child)
+							for prop := range cleanups {
+								v.finallyCleaned[prop] = true
+							}
+						}
+					}
+				}
+				for i := uint(0); i < node.ChildCount(); i++ {
+					preScanFinally(node.Child(i))
+				}
+			}
+			preScanFinally(body)
+		}
 	case "assignment_expression", "augmented_assignment_expression":
 		v.handleMutation(n.ChildByFieldName("left"))
 	case "update_expression":
@@ -125,7 +154,7 @@ func (v *PHPVisitor) walk(n *sitter.Node) {
 		}
 		v.curClass, v.isReset, v.isReadonlyClass, v.readonlyProps, v.isWorkerSafeClass = oldClass, oldIsRes, oldIsReadonly, oldReadonlyProps, oldIsWorkerSafeClass
 	case "method_declaration", "function_definition":
-		v.curMethod, v.isWorkerSafeMethod = oldMethod, oldIsWorkerSafeMethod
+		v.curMethod, v.isWorkerSafeMethod, v.finallyCleaned = oldMethod, oldIsWorkerSafeMethod, oldFinallyCleaned
 	}
 }
 
@@ -383,8 +412,8 @@ func (v *PHPVisitor) logMutation(n *sitter.Node, prop string, static bool) {
 		key = "static::" + prop
 	}
 
-	// Skip if property is readonly or WorkerSafe
-	if !static && (v.readonlyProps[prop] || v.workerSafeProps[prop]) {
+	// Skip if property is readonly, WorkerSafe, or cleaned up in a finally block
+	if !static && (v.readonlyProps[prop] || v.workerSafeProps[prop] || v.finallyCleaned[prop]) {
 		return
 	}
 	if static && v.workerSafeProps[prop] {
@@ -746,4 +775,78 @@ func (v *PHPVisitor) resolveFQCN(typeName string) string {
 		return v.namespace + "\\" + typeName
 	}
 	return typeName
+}
+
+// getFinallyCleanedProperties scans a finally_clause AST node to extract properties of $this that are cleaned up.
+func (v *PHPVisitor) getFinallyCleanedProperties(finallyNode *sitter.Node) map[string]bool {
+	cleanups := make(map[string]bool)
+	if finallyNode == nil {
+		return cleanups
+	}
+
+	var walkFinally func(*sitter.Node)
+	walkFinally = func(node *sitter.Node) {
+		if node == nil {
+			return
+		}
+
+		// 1. Detect function calls like array_pop($this->propertyName) or array_shift($this->propertyName)
+		if node.Kind() == "function_call_expression" {
+			fnNameNode := node.ChildByFieldName("function")
+			if fnNameNode == nil {
+				fnNameNode = node.ChildByFieldName("name")
+			}
+			if fnNameNode != nil {
+				fnName := strings.ToLower(v.getContent(fnNameNode))
+				if fnName == "array_pop" || fnName == "array_shift" {
+					argsNode := node.ChildByFieldName("arguments")
+					if argsNode != nil {
+						for i := uint(0); i < argsNode.ChildCount(); i++ {
+							arg := argsNode.Child(i)
+							if arg.Kind() == "argument" && arg.NamedChildCount() > 0 {
+								expr := arg.NamedChild(0)
+								if expr != nil && expr.Kind() == "member_access_expression" {
+									prop, isProp := v.isPropertyFetchOnThis(expr)
+									if isProp {
+										cleanups[prop] = true
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
+		// 2. Detect assignment expressions like $this->propertyName = null or $this->propertyName = []
+		if node.Kind() == "assignment_expression" {
+			left := node.ChildByFieldName("left")
+			if left != nil && left.Kind() == "member_access_expression" {
+				prop, isProp := v.isPropertyFetchOnThis(left)
+				if isProp {
+					cleanups[prop] = true
+				}
+			}
+		}
+
+		// 3. Detect unset statements like unset($this->propertyName)
+		if node.Kind() == "unset_statement" {
+			for i := uint(0); i < node.ChildCount(); i++ {
+				child := node.Child(i)
+				if child.Kind() == "member_access_expression" {
+					prop, isProp := v.isPropertyFetchOnThis(child)
+					if isProp {
+						cleanups[prop] = true
+					}
+				}
+			}
+		}
+
+		for i := uint(0); i < node.ChildCount(); i++ {
+			walkFinally(node.Child(i))
+		}
+	}
+
+	walkFinally(finallyNode)
+	return cleanups
 }

--- a/internal/analyzer/visitor_test.go
+++ b/internal/analyzer/visitor_test.go
@@ -287,4 +287,50 @@ class MyService implements Symfony\Contracts\Service\ResetInterface {
 	}
 }
 
+func TestPHPVisitor_TryFinallyCleanup(t *testing.T) {
+	code := `<?php
+class AuthorizationChecker {
+    private array $tokenStack = [];
+    private array $accessDecisionStack = [];
+
+    public function isGranted($attribute, $subject = null): bool
+    {
+        $this->accessDecisionStack[] = 'decision';
+
+        try {
+            return true;
+        } finally {
+            array_pop($this->accessDecisionStack);
+        }
+    }
+
+    public function isGrantedForUser($user, $attribute): bool
+    {
+        $this->tokenStack[] = 'token';
+
+        try {
+            return $this->isGranted($attribute);
+        } finally {
+            array_pop($this->tokenStack);
+        }
+    }
+}`
+	content := []byte(code)
+
+	p := sitter.NewParser()
+	lang := sitter.NewLanguage(php.LanguagePHP())
+	_ = p.SetLanguage(lang)
+	tree := p.Parse(content, nil)
+	defer tree.Close()
+
+	engine := &mockEngine{}
+	v := NewVisitor(content, engine)
+	v.Walk(tree.RootNode())
+
+	findings := v.Findings()
+	if len(findings) != 0 {
+		t.Errorf("Expected 0 findings because the state mutations are perfectly cleaned up in finally blocks, got: %v", findings)
+	}
+}
+
 


### PR DESCRIPTION
Introduce lexical pre-scanning of method bodies to extract state cleanups (such as array_pop, array_shift, unsets, or assignments) executed inside finally blocks of try-statements. Bypass state mutation warnings if the mutated property of  is guaranteed to be cleaned up in a finally block, allowing advanced thread-safe stack state management in persistent worker environments. Add comprehensive unit tests.