### PR TITLE
make go version downloading deterministic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Binaries
 igor-php
 !bin/igor-php
+resources/bin/*
 
 # IDEs
 .idea/

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ During its static analysis of shared/singleton services, Igor recursively scans 
 composer require --dev igor-php/igor-php
 ```
 
-When running Igor, the included php bootstrapper for will download the Go binary of Igor in the version matching the installed composer-package version.  
+When running Igor, the included php bootstrapper will download the Go binary of Igor in the version matching the installed composer-package version.  
 You can override this behavior by setting the `IGOR_VERSION` environment variable to a version string (i.e. `0.8.9`) to use a specific version or to `latest` to always get the latest version.
 
 In case your `autoload.php` is not in the standard location `vendor/autoload.php` you have to set it via the `IGOR_AUTOLOAD_LOCATION` environment variable.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ During its static analysis of shared/singleton services, Igor recursively scans 
 composer require --dev igor-php/igor-php
 ```
 
+When running Igor, the included php bootstrapper for will download the Go binary of Igor in the version matching the installed composer-package version.  
+You can override this behavior by setting the `IGOR_VERSION` environment variable to a version string (i.e. `0.8.9`) to use a specific version or to `latest` to always get the latest version.
+
+In case your `autoload.php` is not in the standard location `vendor/autoload.php` you have to set it via the `IGOR_AUTOLOAD_LOCATION` environment variable.
+
 ### Enable the Symfony Bundle (Optional but Recommended)
 To make Igor even more reliable, you can enable the embedded PHP bundle. It generates a precise service map directly from your container, which Igor Go will use to audit your services.
 

--- a/bin/igor-php
+++ b/bin/igor-php
@@ -12,7 +12,13 @@ $bootstrapper = new class()
     {
         $version = self::determineTargetVersion();
         if ($version === null || $version === 'latest') {
+            echo 'ℹ️ Falling back to latest version.';
             $version = self::determineLatestVersion();
+        }
+
+        // Enforce safe alphanumeric characters for the version string
+        if (!preg_match('/^[a-zA-Z0-9.\-_]+$/', $version)) {
+            die("❌ Invalid version format specified.\n");
         }
 
         $os = strtolower(PHP_OS_FAMILY);
@@ -55,12 +61,12 @@ $bootstrapper = new class()
         return $exitCode;
     }
 
-    private static function autoload(): void
+    private static function autoload(): bool
     {
         $autoloadLocationOverride = getenv(self::AUTOLOAD_LOCATION_ENV_VARIABLE_NAME);
         if ($autoloadLocationOverride !== false) {
             require_once $autoloadLocationOverride;
-            return;
+            return true;
         }
 
         $potentialAutoloadLocations = [
@@ -71,30 +77,38 @@ $bootstrapper = new class()
         foreach ($potentialAutoloadLocations as $potentialAutoloadLocation) {
             if (is_file($potentialAutoloadLocation)) {
                 require_once $potentialAutoloadLocation;
-                return;
+                return true;
             }
         }
 
-        die(
-            sprintf(
-                "❌ Igor couldn't find the autoloader.\n Specify autoloader location by setting the %s env variable.",
-                self::AUTOLOAD_LOCATION_ENV_VARIABLE_NAME
-            )
+        echo sprintf(
+            "❌ Igor couldn't find the autoloader.\n Specify autoloader location by setting the %s env variable.",
+            self::AUTOLOAD_LOCATION_ENV_VARIABLE_NAME
         );
+
+        return false;
     }
 
     private static function determineTargetVersion(): ?string
     {
-        $versionOverride = getenv(self::VERSION_ENV_VARIABLE_NAME);
-        if ($versionOverride !== false) {
-            return $versionOverride;
-        }
+        try {
+            $versionOverride = getenv(self::VERSION_ENV_VARIABLE_NAME);
+            if ($versionOverride !== false) {
+                return $versionOverride;
+            }
 
-        self::autoload();
+            if (self::autoload() === false) {
+                return null;
+            }
 
-        $versionString = trim(\Composer\InstalledVersions::getPrettyVersion('igor-php/igor-php'));
-        if (preg_match('/^v?(\d+\.\d+\.\d+)$/', $versionString, $matches) === 1) {
-            return $matches[1];
+            $versionString = trim(\Composer\InstalledVersions::getPrettyVersion('igor-php/igor-php'));
+            if (preg_match('/^v?(\d+\.\d+\.\d+)$/', $versionString, $matches) === 1) {
+                return $matches[1];
+            }
+        } catch(Throwable $throwable) {
+            // Fallback gracefully on local dev clones or non-composer setups
+            echo '⚠️ Error while determining current version:' . PHP_EOL
+                    . $throwable->getMessage();
         }
 
         return null;
@@ -158,9 +172,9 @@ $bootstrapper = new class()
         file_put_contents($tempFile, $content);
 
         if ($os === 'windows') {
-            exec(sprintf("powershell Expand-Archive -Path %s -DestinationPath %s", $tempFile, $targetPath));
+            exec(sprintf("powershell Expand-Archive -Path %s -DestinationPath %s", escapeshellarg($tempFile), escapeshellarg($targetPath)));
         } else {
-            exec(sprintf("tar -xzf %s -C %s", $tempFile, $targetPath));
+            exec(sprintf("tar -xzf %s -C %s", escapeshellarg($tempFile), escapeshellarg($targetPath)));
         }
 
         unlink($tempFile);

--- a/bin/igor-php
+++ b/bin/igor-php
@@ -5,6 +5,7 @@ $bootstrapper = new class()
 {
     private const REPO = 'igor-php/igor-php';
     private const BIN_DIR = __DIR__ . '/../resources/bin';
+    private const VERSION_CACHE_FILE = self::BIN_DIR . '/.latest-version';
     private const VERSION_ENV_VARIABLE_NAME = 'IGOR_VERSION';
     private const AUTOLOAD_LOCATION_ENV_VARIABLE_NAME = 'IGOR_AUTOLOAD_LOCATION';
 
@@ -12,13 +13,13 @@ $bootstrapper = new class()
     {
         $version = self::determineTargetVersion();
         if ($version === null || $version === 'latest') {
-            echo 'ℹ️ Falling back to latest version.';
+            echo 'ℹ️  Falling back to latest version.' . PHP_EOL;
             $version = self::determineLatestVersion();
         }
 
         // Enforce safe alphanumeric characters for the version string
         if (!preg_match('/^[a-zA-Z0-9.\-_]+$/', $version)) {
-            die("❌ Invalid version format specified.\n");
+            die("❌ Invalid version format specified." . PHP_EOL);
         }
 
         $os = strtolower(PHP_OS_FAMILY);
@@ -65,6 +66,10 @@ $bootstrapper = new class()
     {
         $autoloadLocationOverride = getenv(self::AUTOLOAD_LOCATION_ENV_VARIABLE_NAME);
         if ($autoloadLocationOverride !== false) {
+            if (!is_file($autoloadLocationOverride) || !is_readable($autoloadLocationOverride)) {
+                die('❌ Igor could not find autoload location override: ' . $autoloadLocationOverride . PHP_EOL);
+            }
+
             require_once $autoloadLocationOverride;
             return true;
         }
@@ -81,10 +86,7 @@ $bootstrapper = new class()
             }
         }
 
-        echo sprintf(
-            "❌ Igor couldn't find the autoloader.\n Specify autoloader location by setting the %s env variable.",
-            self::AUTOLOAD_LOCATION_ENV_VARIABLE_NAME
-        );
+        echo "ℹ️  Igor couldn't find an autoloader." . PHP_EOL;
 
         return false;
     }
@@ -107,8 +109,7 @@ $bootstrapper = new class()
             }
         } catch(Throwable $throwable) {
             // Fallback gracefully on local dev clones or non-composer setups
-            echo '⚠️ Error while determining current version:' . PHP_EOL
-                    . $throwable->getMessage();
+            echo 'ℹ️  Igor could not determine the current version:' . PHP_EOL;
         }
 
         return null;
@@ -116,6 +117,11 @@ $bootstrapper = new class()
 
     private static function determineLatestVersion(): string
     {
+        // 24-hour cache TTL to prevent hitting GitHub API rate-limits and adding execution latency
+        if (file_exists(self::VERSION_CACHE_FILE) && (time() - filemtime(self::VERSION_CACHE_FILE) < 86400)) {
+            return trim(file_get_contents(self::VERSION_CACHE_FILE));
+        }
+
         $opts = [
             'http' => [
                 'method' => 'GET',
@@ -134,8 +140,9 @@ $bootstrapper = new class()
         if ($response === false) {
             die(
                 sprintf(
-                    "❌ Igor couldn't reach the laboratory. URL: %s\nPlease check your internet connection or specify a Igor version by setting the %s env variable.\n",
+                    "❌ Igor couldn't reach the laboratory. URL: %s%sPlease check your internet connection or specify a Igor version by setting the %s env variable." . PHP_EOL,
                     $url,
+                    PHP_EOL,
                     self::VERSION_ENV_VARIABLE_NAME,
                 )
             );
@@ -143,6 +150,13 @@ $bootstrapper = new class()
 
         $data = json_decode($response, true);
         $version = ltrim($data['tag_name'], 'v');
+
+        $versionCacheDir = dirname(self::VERSION_CACHE_FILE);
+
+        if (!is_dir($versionCacheDir)) {
+            mkdir($versionCacheDir, 0755, true);
+        }
+        file_put_contents(self::VERSION_CACHE_FILE, $version);
 
         return $version;
     }
@@ -153,7 +167,7 @@ $bootstrapper = new class()
             mkdir($targetPath, 0755, true);
         }
 
-        echo "🧟 Igor is waking up... Downloading binary for {$os}/{$arch} (v{$version})...\n";
+        echo "🧟 Igor is waking up... Downloading binary for {$os}/{$arch} (v{$version})..." . PHP_EOL;
 
         // GoReleaser format: igor-php_0.1.0_linux_arm64.tar.gz
         $archiveName = "igor-php_{$version}_{$os}_{$arch}";
@@ -165,7 +179,10 @@ $bootstrapper = new class()
 
         $content = @file_get_contents($url);
         if ($content === false) {
-            die("❌ Igor couldn't reach the laboratory. URL: $url\nPlease check your internet connection or if the release v$version exists on GitHub.\n");
+            die(
+                "❌ Igor couldn't reach the laboratory. URL: $url" . PHP_EOL .
+                "Please check your internet connection or if the release v$version exists on GitHub." . PHP_EOL
+            );
         }
 
         $tempFile = sys_get_temp_dir() . '/igor.tmp';

--- a/bin/igor-php
+++ b/bin/igor-php
@@ -1,98 +1,174 @@
 #!/usr/bin/env php
 <?php
 
-$repo = 'igor-php/igor-php';
-$binDir = __DIR__ . '/../resources/bin';
-$versionFile = $binDir . '/.version';
+$bootstrapper = new class()
+{
+    private const REPO = 'igor-php/igor-php';
+    private const BIN_DIR = __DIR__ . '/../resources/bin';
+    private const VERSION_ENV_VARIABLE_NAME = 'IGOR_VERSION';
+    private const AUTOLOAD_LOCATION_ENV_VARIABLE_NAME = 'IGOR_AUTOLOAD_LOCATION';
 
-// Get version from cache or fetch latest from GitHub
-if (file_exists($versionFile) && (time() - filemtime($versionFile) < 86400)) {
-    $version = trim(file_get_contents($versionFile));
-} else {
-    $opts = [
-        'http' => [
-            'method' => 'GET',
-            'header' => [
-                'User-Agent: Igor-PHP-Bootstrapper'
+    static public function run(array $args): int
+    {
+        $version = self::determineTargetVersion();
+        if ($version === null || $version === 'latest') {
+            $version = self::determineLatestVersion();
+        }
+
+        $os = strtolower(PHP_OS_FAMILY);
+        $arch = php_uname('m');
+
+        // Map architecture names
+        if ($arch === 'x86_64') {
+            $arch = 'amd64';
+        } elseif ($arch === 'arm64' || $arch === 'aarch64') {
+            $arch = 'arm64';
+        }
+
+        // OS Mapping for GoReleaser
+        if ($os === 'darwin') {
+            $os = 'darwin';
+        } elseif ($os === 'windows') {
+            $os = 'windows';
+        } else {
+            $os = 'linux';
+        }
+
+        $versionedBinaryPath = sprintf(
+            "%s/%s_%s_%s/",
+            self::BIN_DIR,
+            str_replace('.', '-', $version),
+            $os,
+            $arch,
+        );
+
+        $extension = ($os === 'windows') ? '.exe' : '';
+        $binaryName = $versionedBinaryPath . 'igor-php' . $extension;
+
+        if (!file_exists($binaryName)) {
+            self::downloadIgorBinary($version, $os, $arch, $versionedBinaryPath, $binaryName);
+        }
+
+        $cmd = escapeshellarg($binaryName) . ' ' . implode(' ', array_map(escapeshellarg(...), $args));
+        passthru($cmd, $exitCode);
+
+        return $exitCode;
+    }
+
+    private static function autoload(): void
+    {
+        $autoloadLocationOverride = getenv(self::AUTOLOAD_LOCATION_ENV_VARIABLE_NAME);
+        if ($autoloadLocationOverride !== false) {
+            require_once $autoloadLocationOverride;
+            return;
+        }
+
+        $potentialAutoloadLocations = [
+            dirname(__DIR__) . '/vendor/autoload.php', // for local development on Igor-php
+            dirname(__DIR__, 4) . '/vendor/autoload.php', // for Igor-php installed in other projects
+        ];
+
+        foreach ($potentialAutoloadLocations as $potentialAutoloadLocation) {
+            if (is_file($potentialAutoloadLocation)) {
+                require_once $potentialAutoloadLocation;
+                return;
+            }
+        }
+
+        die(
+            sprintf(
+                "❌ Igor couldn't find the autoloader.\n Specify autoloader location by setting the %s env variable.",
+                self::AUTOLOAD_LOCATION_ENV_VARIABLE_NAME
+            )
+        );
+    }
+
+    private static function determineTargetVersion(): ?string
+    {
+        $versionOverride = getenv(self::VERSION_ENV_VARIABLE_NAME);
+        if ($versionOverride !== false) {
+            return $versionOverride;
+        }
+
+        self::autoload();
+
+        $versionString = trim(\Composer\InstalledVersions::getPrettyVersion('igor-php/igor-php'));
+        if (preg_match('/^v?(\d+\.\d+\.\d+)$/', $versionString, $matches) === 1) {
+            return $matches[1];
+        }
+
+        return null;
+    }
+
+    private static function determineLatestVersion(): string
+    {
+        $opts = [
+            'http' => [
+                'method' => 'GET',
+                'header' => [
+                    'User-Agent: Igor-PHP-Bootstrapper'
+                ]
             ]
-        ]
-    ];
-    $context = stream_context_create($opts);
-    $response = @file_get_contents("https://api.github.com/repos/{$repo}/releases/latest", false, $context);
-    
-    if ($response) {
+        ];
+        $context = stream_context_create($opts);
+        $url = sprintf(
+            "https://api.github.com/repos/%s/releases/latest",
+            self::REPO
+        );
+        $response = @file_get_contents($url, false, $context);
+
+        if ($response === false) {
+            die(
+                sprintf(
+                    "❌ Igor couldn't reach the laboratory. URL: %s\nPlease check your internet connection or specify a Igor version by setting the %s env variable.\n",
+                    $url,
+                    self::VERSION_ENV_VARIABLE_NAME,
+                )
+            );
+        }
+
         $data = json_decode($response, true);
         $version = ltrim($data['tag_name'], 'v');
-        if (!is_dir($binDir)) {
-            mkdir($binDir, 0755, true);
+
+        return $version;
+    }
+
+    static private function downloadIgorBinary(string $version, string $os, string $arch, string $targetPath, string $fullBinaryName): void
+    {
+        if (!is_dir($targetPath)) {
+            mkdir($targetPath, 0755, true);
         }
-        file_put_contents($versionFile, $version);
-    } else {
-        // Fallback to a safe version if API fails
-        $version = file_exists($versionFile) ? trim(file_get_contents($versionFile)) : '0.1.4';
+
+        echo "🧟 Igor is waking up... Downloading binary for {$os}/{$arch} (v{$version})...\n";
+
+        // GoReleaser format: igor-php_0.1.0_linux_arm64.tar.gz
+        $archiveName = "igor-php_{$version}_{$os}_{$arch}";
+        $url = "https://github.com/igor-php/igor-php/releases/download/v{$version}/{$archiveName}.tar.gz";
+
+        if ($os === 'windows') {
+            $url = "https://github.com/igor-php/igor-php/releases/download/v{$version}/{$archiveName}.zip";
+        }
+
+        $content = @file_get_contents($url);
+        if ($content === false) {
+            die("❌ Igor couldn't reach the laboratory. URL: $url\nPlease check your internet connection or if the release v$version exists on GitHub.\n");
+        }
+
+        $tempFile = sys_get_temp_dir() . '/igor.tmp';
+        file_put_contents($tempFile, $content);
+
+        if ($os === 'windows') {
+            exec(sprintf("powershell Expand-Archive -Path %s -DestinationPath %s", $tempFile, $targetPath));
+        } else {
+            exec(sprintf("tar -xzf %s -C %s", $tempFile, $targetPath));
+        }
+
+        unlink($tempFile);
+
+        if (file_exists($fullBinaryName)) {
+            chmod($fullBinaryName, 0755);
+        }
     }
-}
+};
 
-$os = strtolower(PHP_OS_FAMILY);
-$arch = php_uname('m');
-
-// Map architecture names
-if ($arch === 'x86_64') {
-    $arch = 'amd64';
-} elseif ($arch === 'arm64' || $arch === 'aarch64') {
-    $arch = 'arm64';
-}
-
-// OS Mapping for GoReleaser
-if ($os === 'darwin') {
-    $os = 'darwin';
-} elseif ($os === 'windows') {
-    $os = 'windows';
-} else {
-    $os = 'linux';
-}
-
-$extension = ($os === 'windows') ? '.exe' : '';
-$binaryName = "igor-php";
-$localBinary = "{$binDir}/{$binaryName}{$extension}";
-
-if (!file_exists($localBinary)) {
-    if (!is_dir($binDir)) {
-        mkdir($binDir, 0755, true);
-    }
-
-    echo "🧟 Igor is waking up... Downloading binary for {$os}/{$arch} (v{$version})...\n";
-    
-    // GoReleaser format: igor-php_0.1.0_linux_arm64.tar.gz
-    $archiveName = "igor-php_{$version}_{$os}_{$arch}";
-    $url = "https://github.com/igor-php/igor-php/releases/download/v{$version}/{$archiveName}.tar.gz";
-    
-    if ($os === 'windows') {
-        $url = "https://github.com/igor-php/igor-php/releases/download/v{$version}/{$archiveName}.zip";
-    }
-
-    $content = @file_get_contents($url);
-    if ($content === false) {
-        die("❌ Igor couldn't reach the laboratory. URL: $url\nPlease check your internet connection or if the release v$version exists on GitHub.\n");
-    }
-
-    $tempFile = sys_get_temp_dir() . '/igor.tmp';
-    file_put_contents($tempFile, $content);
-
-    if ($os === 'windows') {
-        exec("powershell Expand-Archive -Path $tempFile -DestinationPath $binDir");
-    } else {
-        exec("tar -xzf $tempFile -C $binDir");
-    }
-    
-    unlink($tempFile);
-    if (file_exists($localBinary)) {
-        chmod($localBinary, 0755);
-    }
-}
-
-$args = array_slice($argv, 1);
-$cmd = escapeshellarg($localBinary) . ' ' . implode(' ', array_map('escapeshellarg', $args));
-
-passthru($cmd, $exitCode);
-exit($exitCode);
+exit($bootstrapper::run(array_slice($argv, 1)));

--- a/bin/igor-php
+++ b/bin/igor-php
@@ -138,6 +138,14 @@ $bootstrapper = new class()
         $response = @file_get_contents($url, false, $context);
 
         if ($response === false) {
+            // Offline fallback: Use the expired cache if available
+            if (file_exists(self::VERSION_CACHE_FILE) && is_readable(self::VERSION_CACHE_FILE)) {
+                echo "ℹ️  Igor couldn't reach the laboratory - using cached version." . PHP_EOL;
+                // Update mtime so we don't block on the failing API call on the very next runs
+                @touch(self::VERSION_CACHE_FILE);
+                return trim(file_get_contents(self::VERSION_CACHE_FILE));
+            }
+
             die(
                 sprintf(
                     "❌ Igor couldn't reach the laboratory. URL: %s%sPlease check your internet connection or specify a Igor version by setting the %s env variable." . PHP_EOL,


### PR DESCRIPTION
## Context

Currently, when installed as composer package, Igor-php will always download the latest version of the Go binary. This causes non-deterministic behavior and can lead to issues especially in CI/CD pipelines.

Fixes #51 


## Implementation

Following changes were made in the scope of this PR:

- bin/igor-php
  - move logic into an anonymous class in order to not pollute the global scope
  - require the autoload file and determine the currently installed version via Composer using the latest version as a fallback e.g. for local development on Igor itself.
  - introduce `IGOR_VERSION` environment variable to override the target version - can be a version string or `latest` to always fetch the latest version
  - downloaded binaries are now organized in subfolder within the `/resources/bin/` folder to cleanly separate versions and architectures
- README.md updated to describe new behavior

## Requirements

*Please ensure that your PR is ready by checking the appropriate boxes. If an action is not applicable (e.g., configuration changes), you can mark it as checked or note it as N/A.*

- [x] I have performed a self code-review.
- [x] (N/A) I have added / updated unit and integration tests to verify my changes.
- [x] I have updated the documentation / README if applicable.
- [x] (N/A) I have run local CI checks (`make ci`) and all checks passed.
- [x] I have performed manual tests to ensure the changes work as intended.

## Documentations

See README.md - Installation

## Manual tests

**Run with empty bin folder - local development**
- Version is detected as `dev-main`
- Latest version is fetches as fallback (in my case 0.8.9)
- Igor was downloaded and extracted into `resources/bin/0-8-9_darwin_arm64`

**Consecutive runs - local development and inside a project**
- The already downloaded binary is used, no download was triggered

**Consecutive runs with clearing the bin folder inbetween - local development and inside a project**
- Binary is downloaded and extracted again accoring to defined logic

**Run with empty bin folder - inside a project (igor-php was just replaced inside the vendor folder)**
- Version is detected as `0.8.1` (correct as the composer.lock states version 0.8.1 installed
- v0.8.1 of Igor was downloaded and extracted into `resources/bin/0-8-1_darwin_arm64`

**Run with version override `0.8.4` (`IGOR_VERSION=0.8.4 php vendor/bin/igor`) - local dev and inside project**
- No version resolution was triggered
- Version 0.8.4 was downloaded and extracted into `resources/bin/0-8-4_darwin_arm64`

**Renamed `vendor` to `vendor__` and set custom autoloader path (`IGOR_AUTOLOAD_LOCATION="vendor__/autoload.php" php vendor/bin/igor`) - local dev and inside project**
- Custom autoload file was required
- Installed package version was correctly resolved