### PR TITLE
fix: ensure inherited classes and traits respect safe_namespaces

### DIFF
--- a/cmd/igor/collect_files_test.go
+++ b/cmd/igor/collect_files_test.go
@@ -98,3 +98,70 @@ func TestCollectFiles_SymfonyActive_SkipsLocalFiles(t *testing.T) {
 		t.Errorf("Expected both files to be collected when Symfony is inactive. Got MyService.php: %t, MyEntity.php: %t", hasServiceInactive, hasEntityInactive)
 	}
 }
+
+func TestCollectFiles_SkipsSafeNamespacesInherited(t *testing.T) {
+	// 1. Create a temporary project directory
+	tmpDir, err := os.MkdirTemp("", "collect_files_safe_*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	srcDir := filepath.Join(tmpDir, "src")
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatalf("Failed to create src dir: %v", err)
+	}
+
+	servicePath := filepath.Join(srcDir, "MyService.php")
+	if err := os.WriteFile(servicePath, []byte("<?php class MyService {}"), 0644); err != nil {
+		t.Fatalf("Failed to write service file: %v", err)
+	}
+
+	inheritedPath := filepath.Join(srcDir, "MyInheritedSafeService.php")
+	if err := os.WriteFile(inheritedPath, []byte("<?php class MyInheritedSafeService {}"), 0644); err != nil {
+		t.Fatalf("Failed to write inherited file: %v", err)
+	}
+
+	cfg := config.Config{
+		NoAgent:        true,
+		SafeNamespaces: []string{"Symfony\\", "App\\Safe\\"},
+	}
+
+	aud := auditor.NewAuditor(cfg)
+	bridge := auditor.NewSymfonyBridge(tmpDir, "bin/console", cfg)
+	bridge.Container = &symbol.SymfonyContainer{
+		Definitions: map[string]symbol.SymfonyService{
+			"app.my_service": {
+				Class:  "App\\Service\\MyService",
+				Public: true,
+				Shared: true,
+			},
+		},
+	}
+	bridge.ClassToFile = map[string]string{
+		"App\\Service\\MyService":           servicePath,
+		"App\\Safe\\MyInheritedSafeService": inheritedPath,
+	}
+	aud.Symfony = bridge
+
+	auditList := collectFiles(tmpDir, cfg, aud)
+
+	// App\\Safe\\MyInheritedSafeService must be skipped since it is in a safe namespace.
+	hasService := false
+	hasInherited := false
+	for _, item := range auditList {
+		if filepath.Base(item.FilePath) == "MyService.php" {
+			hasService = true
+		}
+		if filepath.Base(item.FilePath) == "MyInheritedSafeService.php" {
+			hasInherited = true
+		}
+	}
+
+	if !hasService {
+		t.Error("Expected MyService.php to be collected")
+	}
+	if hasInherited {
+		t.Error("Expected App\\Safe\\MyInheritedSafeService to be skipped due to safe namespace prefix, but it was collected")
+	}
+}

--- a/cmd/igor/main.go
+++ b/cmd/igor/main.go
@@ -596,6 +596,9 @@ func collectFiles(rootPath string, cfg config.Config, aud *auditor.Auditor) []sy
 			if processedFiles[path] {
 				continue
 			}
+			if aud.IsSafeNamespace(class) {
+				continue
+			}
 			if skip, _ := shouldSkipServicePath("", path, cfg, aud, rootPath); skip {
 				continue
 			}

--- a/internal/analyzer/visitor.go
+++ b/internal/analyzer/visitor.go
@@ -528,6 +528,14 @@ func (v *PHPVisitor) addFinding(n *sitter.Node, msg, hint, severity string) {
 		return
 	}
 
+	fullName := v.curClass
+	if v.namespace != "" {
+		fullName = v.namespace + "\\" + v.curClass
+	}
+	if v.engine != nil && v.engine.IsSafeNamespace(fullName) {
+		return
+	}
+
 	row := int(n.StartPosition().Row)
 	lineContent := v.lines[row]
 

--- a/internal/analyzer/visitor_test.go
+++ b/internal/analyzer/visitor_test.go
@@ -684,3 +684,41 @@ class ConcreteAdapterWithLocalProps implements Symfony\Contracts\Service\ResetIn
 		t.Error("Expected a warning for local property 'localProp' in ConcreteAdapterWithLocalProps")
 	}
 }
+
+type mockSafeNamespaceEngine struct {
+	mockEngine
+	safeNamespace string
+}
+
+func (m *mockSafeNamespaceEngine) IsSafeNamespace(className string) bool {
+	return className == m.safeNamespace
+}
+
+func TestPHPVisitor_IsSafeNamespaceBypass(t *testing.T) {
+	code := `<?php
+namespace Symfony\Component\HttpClient;
+
+class CachingHttpClient {
+    public function doSomething() {
+        static $attemptTag = null;
+    }
+}`
+	content := []byte(code)
+
+	p := sitter.NewParser()
+	lang := sitter.NewLanguage(php.LanguagePHP())
+	_ = p.SetLanguage(lang)
+	tree := p.Parse(content, nil)
+	defer tree.Close()
+
+	engine := &mockSafeNamespaceEngine{
+		safeNamespace: "Symfony\\Component\\HttpClient\\CachingHttpClient",
+	}
+	v := NewVisitor(content, engine)
+	v.Walk(tree.RootNode())
+
+	findings := v.Findings()
+	if len(findings) > 0 {
+		t.Errorf("Expected 0 findings inside safe namespace, got %d: %v", len(findings), findings)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,7 @@ func DefaultConfig() Config {
 		SafeNamespaces: []string{
 			"Symfony\\",
 			"Doctrine\\",
+			"Psr\\",
 			"IgorPhp\\IgorBundle\\",
 		},
 		ConsolePath: "bin/console",
@@ -103,7 +104,7 @@ func InitConfig(root string, customConfigPath string) (string, error) {
 	// Minimal base configuration
 	c := Config{
 		Exclude:        []string{},
-		SafeNamespaces: []string{},
+		SafeNamespaces: []string{"Psr\\"},
 		ConsolePath:    "bin/console",
 		Env:            "prod",
 		Verbose:        false,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -103,11 +103,16 @@ func InitConfig(root string, customConfigPath string) (string, error) {
 
 	// Minimal base configuration
 	c := Config{
-		Exclude:        []string{},
-		SafeNamespaces: []string{"Psr\\"},
-		ConsolePath:    "bin/console",
-		Env:            "prod",
-		Verbose:        false,
+		Exclude: []string{},
+		SafeNamespaces: []string{
+			"Symfony\\",
+			"Doctrine\\",
+			"Psr\\",
+			"IgorPhp\\IgorBundle\\",
+		},
+		ConsolePath: "bin/console",
+		Env:         "prod",
+		Verbose:     false,
 	}
 	projectType := "Generic PHP"
 


### PR DESCRIPTION
- In collectFiles, skip parent classes and traits resolved by reflection if they belong to a safe namespace
- In PHPVisitor, bypass registering findings if the active class is in a safe namespace
- Add "Psr\" to default safe namespaces in DefaultConfig and InitConfig
- Add unit and integration tests to verify both file collection and visitor-level safe namespace exclusion

## Context

*Provide a clear and concise description of the context (the feature, improvement, or the bug you are fixing).*

*If this PR is linked to an existing GitHub issue, please reference it here (e.g. `Closes #123`).*

## Implementation

*Explain how you resolved the issue or implemented the feature. Share any architectural decisions, additions, or modifications.*

## Requirements

*Please ensure that your PR is ready by checking the appropriate boxes. If an action is not applicable (e.g., configuration changes), you can mark it as checked or note it as N/A.*

- [ ] I have performed a self code-review.
- [ ] I have added / updated unit and integration tests to verify my changes.
- [ ] I have updated the documentation / README if applicable.
- [ ] I have run local CI checks (`make ci`) and all checks passed.
- [ ] I have performed manual tests to ensure the changes work as intended.

## Documentations

*Add links to updated documentation if applicable.*

## Manual tests

*Describe the manual tests you performed in addition to automated tests to verify your implementation (this helps reviewers verify your work).*

- **Test Case:**
- **Observed Result:**

## Performance tests (optional)

*If this PR introduces major AST parsing or auditing logic changes, share any benchmark or execution time results.*

## Screenshots (optional)

*Add screenshots or terminal recordings/GIFs if this PR introduces visual or formatting changes to the command-line output.*
