### PR TITLE
fix: ignore external baselines during check and prune commands

### DIFF
--- a/cmd/igor/external_baseline_test.go
+++ b/cmd/igor/external_baseline_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/igor-php/igor-php/internal/config"
 )
 
-func TestExternalBaselineAutoDiscoveryAndMerging(t *testing.T) {
+func setupTestExternalBaselineDir(t *testing.T) (string, func()) {
+	t.Helper()
 	// Create a temporary root directory for the parent project
 	tmpDir, err := os.MkdirTemp("", "igor_external_baseline_test")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	// Create vendor structure
 	vendorDir := filepath.Join(tmpDir, "vendor")
@@ -22,9 +22,11 @@ func TestExternalBaselineAutoDiscoveryAndMerging(t *testing.T) {
 	pkg2Dir := filepath.Join(vendorDir, "acme", "package2")
 
 	if err := os.MkdirAll(pkg1Dir, 0755); err != nil {
+		_ = os.RemoveAll(tmpDir)
 		t.Fatal(err)
 	}
 	if err := os.MkdirAll(pkg2Dir, 0755); err != nil {
+		_ = os.RemoveAll(tmpDir)
 		t.Fatal(err)
 	}
 
@@ -38,6 +40,7 @@ func TestExternalBaselineAutoDiscoveryAndMerging(t *testing.T) {
 	}`
 	err = os.WriteFile(filepath.Join(pkg1Dir, "igor-baseline.json"), []byte(pkg1BaselineContent), 0644)
 	if err != nil {
+		_ = os.RemoveAll(tmpDir)
 		t.Fatal(err)
 	}
 
@@ -51,6 +54,7 @@ func TestExternalBaselineAutoDiscoveryAndMerging(t *testing.T) {
 	}`
 	err = os.WriteFile(filepath.Join(pkg2Dir, "custom-baseline.json"), []byte(pkg2BaselineContent), 0644)
 	if err != nil {
+		_ = os.RemoveAll(tmpDir)
 		t.Fatal(err)
 	}
 
@@ -59,6 +63,7 @@ func TestExternalBaselineAutoDiscoveryAndMerging(t *testing.T) {
 	}`
 	err = os.WriteFile(filepath.Join(pkg2Dir, "igor.json"), []byte(pkg2ConfigContent), 0644)
 	if err != nil {
+		_ = os.RemoveAll(tmpDir)
 		t.Fatal(err)
 	}
 
@@ -73,63 +78,118 @@ func TestExternalBaselineAutoDiscoveryAndMerging(t *testing.T) {
 	rootBaselinePath := filepath.Join(tmpDir, "igor-baseline.json")
 	err = os.WriteFile(rootBaselinePath, []byte(rootBaselineContent), 0644)
 	if err != nil {
+		_ = os.RemoveAll(tmpDir)
 		t.Fatal(err)
 	}
 
-	t.Run("Should load both root and external baselines when ignore_external_baseline is false", func(t *testing.T) {
-		cfg := config.Config{
-			BaselinePath:           "igor-baseline.json",
-			IgnoreExternalBaseline: false,
-		}
+	return tmpDir, func() { _ = os.RemoveAll(tmpDir) }
+}
 
-		baseline := loadAuditBaseline(tmpDir, cfg)
+func TestExternalBaseline_AutoDiscoveryAndMerging(t *testing.T) {
+	tmpDir, cleanup := setupTestExternalBaselineDir(t)
+	defer cleanup()
 
-		// Check root baseline
-		if _, found := baseline.Files["src/AppService.php"]; !found {
-			t.Error("Expected root baseline entry to be loaded")
-		}
+	cfg := config.Config{
+		BaselinePath:           "igor-baseline.json",
+		IgnoreExternalBaseline: false,
+	}
 
-		// Check package1 auto-discovered baseline with translated paths
-		p1Path := filepath.Join("vendor", "acme", "package1", "src/Service1.php")
-		p1Entries, found := baseline.Files[p1Path]
-		if !found {
-			t.Errorf("Expected package1 baseline path %q to be loaded", p1Path)
-		} else if len(p1Entries) != 1 || p1Entries[0].Message != "State mutation detected in Service1" {
-			t.Errorf("Unexpected entries for package1: %v", p1Entries)
-		}
+	baseline := loadAuditBaseline(tmpDir, cfg)
 
-		// Check package2 auto-discovered baseline with custom baseline path & translated paths
-		p2Path := filepath.Join("vendor", "acme", "package2", "src/Service2.php")
-		p2Entries, found := baseline.Files[p2Path]
-		if !found {
-			t.Errorf("Expected package2 baseline path %q to be loaded", p2Path)
-		} else if len(p2Entries) != 1 || p2Entries[0].Message != "State mutation detected in Service2" {
-			t.Errorf("Unexpected entries for package2: %v", p2Entries)
-		}
-	})
+	// Check root baseline
+	if _, found := baseline.Files["src/AppService.php"]; !found {
+		t.Error("Expected root baseline entry to be loaded")
+	}
 
-	t.Run("Should load only root baseline when ignore_external_baseline is true", func(t *testing.T) {
-		cfg := config.Config{
-			BaselinePath:           "igor-baseline.json",
-			IgnoreExternalBaseline: true,
-		}
+	// Check package1 auto-discovered baseline with translated paths
+	p1Path := filepath.Join("vendor", "acme", "package1", "src/Service1.php")
+	p1Entries, found := baseline.Files[p1Path]
+	if !found {
+		t.Errorf("Expected package1 baseline path %q to be loaded", p1Path)
+	} else if len(p1Entries) != 1 || p1Entries[0].Message != "State mutation detected in Service1" {
+		t.Errorf("Unexpected entries for package1: %v", p1Entries)
+	}
 
-		baseline := loadAuditBaseline(tmpDir, cfg)
+	// Check package2 auto-discovered baseline with custom baseline path & translated paths
+	p2Path := filepath.Join("vendor", "acme", "package2", "src/Service2.php")
+	p2Entries, found := baseline.Files[p2Path]
+	if !found {
+		t.Errorf("Expected package2 baseline path %q to be loaded", p2Path)
+	} else if len(p2Entries) != 1 || p2Entries[0].Message != "State mutation detected in Service2" {
+		t.Errorf("Unexpected entries for package2: %v", p2Entries)
+	}
+}
 
-		// Check root baseline
-		if _, found := baseline.Files["src/AppService.php"]; !found {
-			t.Error("Expected root baseline entry to be loaded")
-		}
+func TestExternalBaseline_IgnoreExternal(t *testing.T) {
+	tmpDir, cleanup := setupTestExternalBaselineDir(t)
+	defer cleanup()
 
-		// Check external baselines are ignored
-		p1Path := filepath.Join("vendor", "acme", "package1", "src/Service1.php")
-		if _, found := baseline.Files[p1Path]; found {
-			t.Errorf("Expected package1 baseline path %q to be ignored", p1Path)
-		}
+	cfg := config.Config{
+		BaselinePath:           "igor-baseline.json",
+		IgnoreExternalBaseline: true,
+	}
 
-		p2Path := filepath.Join("vendor", "acme", "package2", "src/Service2.php")
-		if _, found := baseline.Files[p2Path]; found {
-			t.Errorf("Expected package2 baseline path %q to be ignored", p2Path)
-		}
-	})
+	baseline := loadAuditBaseline(tmpDir, cfg)
+
+	// Check root baseline
+	if _, found := baseline.Files["src/AppService.php"]; !found {
+		t.Error("Expected root baseline entry to be loaded")
+	}
+
+	// Check external baselines are ignored
+	p1Path := filepath.Join("vendor", "acme", "package1", "src/Service1.php")
+	if _, found := baseline.Files[p1Path]; found {
+		t.Errorf("Expected package1 baseline path %q to be ignored", p1Path)
+	}
+
+	p2Path := filepath.Join("vendor", "acme", "package2", "src/Service2.php")
+	if _, found := baseline.Files[p2Path]; found {
+		t.Errorf("Expected package2 baseline path %q to be ignored", p2Path)
+	}
+}
+
+func TestExternalBaseline_CheckBaseline(t *testing.T) {
+	tmpDir, cleanup := setupTestExternalBaselineDir(t)
+	defer cleanup()
+
+	cfg := config.Config{
+		BaselinePath:  "igor-baseline.json",
+		CheckBaseline: true,
+	}
+
+	baseline := loadAuditBaseline(tmpDir, cfg)
+
+	// Check root baseline
+	if _, found := baseline.Files["src/AppService.php"]; !found {
+		t.Error("Expected root baseline entry to be loaded")
+	}
+
+	// Check external baselines are ignored under check-baseline
+	p1Path := filepath.Join("vendor", "acme", "package1", "src/Service1.php")
+	if _, found := baseline.Files[p1Path]; found {
+		t.Errorf("Expected package1 baseline path %q to be ignored under check-baseline", p1Path)
+	}
+}
+
+func TestExternalBaseline_PruneBaseline(t *testing.T) {
+	tmpDir, cleanup := setupTestExternalBaselineDir(t)
+	defer cleanup()
+
+	cfg := config.Config{
+		BaselinePath:  "igor-baseline.json",
+		PruneBaseline: true,
+	}
+
+	baseline := loadAuditBaseline(tmpDir, cfg)
+
+	// Check root baseline
+	if _, found := baseline.Files["src/AppService.php"]; !found {
+		t.Error("Expected root baseline entry to be loaded")
+	}
+
+	// Check external baselines are ignored under prune-baseline
+	p1Path := filepath.Join("vendor", "acme", "package1", "src/Service1.php")
+	if _, found := baseline.Files[p1Path]; found {
+		t.Errorf("Expected package1 baseline path %q to be ignored under prune-baseline", p1Path)
+	}
 }

--- a/cmd/igor/main.go
+++ b/cmd/igor/main.go
@@ -151,7 +151,7 @@ func loadAuditBaseline(rootPath string, cfg config.Config) config.Baseline {
 		}
 	}
 
-	if !cfg.IgnoreExternalBaseline {
+	if !cfg.IgnoreExternalBaseline && !cfg.CheckBaseline && !cfg.PruneBaseline {
 		discoverAndMergeExternalBaselines(rootPath, cfg, &baseline)
 	}
 


### PR DESCRIPTION
- Skip loading and merging external vendor baselines in loadAuditBaseline when --check-baseline or --prune-baseline are true
- Add unit/integration tests in cmd/igor/external_baseline_test.go to verify this behavior
- Split tests in cmd/igor/external_baseline_test.go to resolve gocyclo complexity warnings

## Context

*Provide a clear and concise description of the context (the feature, improvement, or the bug you are fixing).*

*If this PR is linked to an existing GitHub issue, please reference it here (e.g. `Closes #123`).*

## Implementation

*Explain how you resolved the issue or implemented the feature. Share any architectural decisions, additions, or modifications.*

## Requirements

*Please ensure that your PR is ready by checking the appropriate boxes. If an action is not applicable (e.g., configuration changes), you can mark it as checked or note it as N/A.*

- [ ] I have performed a self code-review.
- [ ] I have added / updated unit and integration tests to verify my changes.
- [ ] I have updated the documentation / README if applicable.
- [ ] I have run local CI checks (`make ci`) and all checks passed.
- [ ] I have performed manual tests to ensure the changes work as intended.

## Documentations

*Add links to updated documentation if applicable.*

## Manual tests

*Describe the manual tests you performed in addition to automated tests to verify your implementation (this helps reviewers verify your work).*

- **Test Case:**
- **Observed Result:**

## Performance tests (optional)

*If this PR introduces major AST parsing or auditing logic changes, share any benchmark or execution time results.*

## Screenshots (optional)

*Add screenshots or terminal recordings/GIFs if this PR introduces visual or formatting changes to the command-line output.*
