### PR TITLE
FEAT 66 : Add link for external baselines with symlink vendor package

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,31 @@ If your project depends on other local packages or vendor dependencies that also
 - **Auto-Discovery**: Igor scans all packages inside `vendor/`. If a vendor package contains an `igor.json` with a custom `baseline` path, or has a default `igor-baseline.json` file in its directory, Igor loads it.
 - **Path Translation**: Igor translates the relative paths within the vendor baseline (e.g., `src/Service.php` in the package) into the context of the parent project (e.g., `vendor/acme/package1/src/Service.php`).
 - **Seamless Merging**: These translated paths are merged on the fly into the active baseline, meaning you won't have to manually copy-paste external baseline entries into your project's baseline!
+- **Symlink Support**: If a local vendor package is installed as a symbolic link (e.g., via Composer's `path` repository type under development), Igor automatically detects the symlink, follows its target to discover the baseline, and maps analyzed file paths back to their vendor-relative equivalents (`vendor/acme/my-bundle/...`).
+
+#### 🔍 Debugging Discovered External Baselines
+To list all discovered vendor baselines, check their type (regular file vs. symbolic link), and inspect all ignored rules along with their documented reasons, run the debug subcommand:
+
+```bash
+igor-php debug-external-baseline [directory]
+```
+
+This will print a clean tree structure of all active external baselines:
+
+```text
+🔍 Debugging external baselines for project at: /Users/thomas/projects/my-project
+
+🛡️  Found regular external baseline for package acme/package1 at: /Users/thomas/projects/my-project/vendor/acme/package1/igor-baseline.json (1 files ignored)
+🛡️  Found symlinked external baseline for package acme/package3 at: /Users/thomas/projects/local-packages/package3/igor-baseline.json (1 files ignored)
+🛡️  Loaded 2 external baseline paths from vendor dependencies.
+
+📋 Summary of loaded baseline files:
+   - vendor/acme/package1/src/Service1.php (1 rules ignored)
+       • State mutation detected in Service1
+           ◦ Reason: Legacy code needing refactor
+   - vendor/acme/package3/src/Service3.php (1 rules ignored)
+       • State mutation detected in Service3
+```
 
 If you want to disable this behavior and only apply your root project's baseline:
 

--- a/cmd/igor/external_baseline_test.go
+++ b/cmd/igor/external_baseline_test.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/igor-php/igor-php/internal/config"
+	"github.com/igor-php/igor-php/pkg/symbol"
 )
 
 func setupTestExternalBaselineDir(t *testing.T) (string, func()) {
@@ -34,7 +37,10 @@ func setupTestExternalBaselineDir(t *testing.T) (string, func()) {
 	pkg1BaselineContent := `{
 		"files": {
 			"src/Service1.php": [
-				{"message": "State mutation detected in Service1"}
+				{
+					"message": "State mutation detected in Service1",
+					"reason": "Legacy code needing refactor"
+				}
 			]
 		}
 	}`
@@ -94,7 +100,7 @@ func TestExternalBaseline_AutoDiscoveryAndMerging(t *testing.T) {
 		IgnoreExternalBaseline: false,
 	}
 
-	baseline := loadAuditBaseline(tmpDir, cfg)
+	baseline := loadAuditBaseline(tmpDir, &cfg)
 
 	// Check root baseline
 	if _, found := baseline.Files["src/AppService.php"]; !found {
@@ -129,7 +135,7 @@ func TestExternalBaseline_IgnoreExternal(t *testing.T) {
 		IgnoreExternalBaseline: true,
 	}
 
-	baseline := loadAuditBaseline(tmpDir, cfg)
+	baseline := loadAuditBaseline(tmpDir, &cfg)
 
 	// Check root baseline
 	if _, found := baseline.Files["src/AppService.php"]; !found {
@@ -157,7 +163,7 @@ func TestExternalBaseline_CheckBaseline(t *testing.T) {
 		CheckBaseline: true,
 	}
 
-	baseline := loadAuditBaseline(tmpDir, cfg)
+	baseline := loadAuditBaseline(tmpDir, &cfg)
 
 	// Check root baseline
 	if _, found := baseline.Files["src/AppService.php"]; !found {
@@ -180,7 +186,7 @@ func TestExternalBaseline_PruneBaseline(t *testing.T) {
 		PruneBaseline: true,
 	}
 
-	baseline := loadAuditBaseline(tmpDir, cfg)
+	baseline := loadAuditBaseline(tmpDir, &cfg)
 
 	// Check root baseline
 	if _, found := baseline.Files["src/AppService.php"]; !found {
@@ -191,5 +197,125 @@ func TestExternalBaseline_PruneBaseline(t *testing.T) {
 	p1Path := filepath.Join("vendor", "acme", "package1", "src/Service1.php")
 	if _, found := baseline.Files[p1Path]; found {
 		t.Errorf("Expected package1 baseline path %q to be ignored under prune-baseline", p1Path)
+	}
+}
+
+func TestExternalBaseline_SymlinkedBundle(t *testing.T) {
+	// Create a temporary root directory for the parent project
+	tmpDir, err := os.MkdirTemp("", "igor_symlink_baseline_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpDir, err = filepath.EvalSymlinks(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// Create vendor structure
+	vendorDir := filepath.Join(tmpDir, "vendor")
+	orgDir := filepath.Join(vendorDir, "acme")
+	if err := os.MkdirAll(orgDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create target bundle directory outside vendor
+	localPackagesDir := filepath.Join(tmpDir, "local-packages")
+	pkg3Dir := filepath.Join(localPackagesDir, "package3")
+	if err := os.MkdirAll(filepath.Join(pkg3Dir, "src"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create baseline file for package3
+	pkg3BaselineContent := `{
+		"files": {
+			"src/Service3.php": [
+				{"message": "State mutation detected in Service3"}
+			]
+		}
+	}`
+	err = os.WriteFile(filepath.Join(pkg3Dir, "igor-baseline.json"), []byte(pkg3BaselineContent), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create symbolic link under vendor pointing to package3 outside vendor
+	symlinkPath := filepath.Join(orgDir, "package3")
+	err = os.Symlink(pkg3Dir, symlinkPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config.Config{
+		BaselinePath:           "igor-baseline.json",
+		IgnoreExternalBaseline: false,
+	}
+
+	// Load the baseline
+	baseline := loadAuditBaseline(tmpDir, &cfg)
+
+	p3Path := filepath.Join("vendor", "acme", "package3", "src/Service3.php")
+	p3Entries, found := baseline.Files[p3Path]
+	if !found {
+		t.Fatalf("Expected package3 baseline path %q to be loaded", p3Path)
+	}
+	if len(p3Entries) != 1 || p3Entries[0].Message != "State mutation detected in Service3" {
+		t.Errorf("Unexpected entries for package3: %v", p3Entries)
+	}
+
+	// Test path translation during FilterFindings (simulating PHP reflection's real path)
+	realFilePath := filepath.Join(pkg3Dir, "src/Service3.php")
+	normalizedPath := cfg.NormalizePath(realFilePath)
+	findings := []symbol.Finding{
+		{Message: "State mutation detected in Service3"},
+	}
+
+	filtered := config.FilterFindings(baseline, normalizedPath, findings, tmpDir)
+	if len(filtered) != 0 {
+		t.Errorf("Expected findings for symlinked file %q (normalized: %q) to be filtered out by baseline, but got: %v", realFilePath, normalizedPath, filtered)
+	}
+}
+
+func TestExternalBaseline_DebugSubcommand(t *testing.T) {
+	tmpDir, cleanup := setupTestExternalBaselineDir(t)
+	defer cleanup()
+
+	// Redirect stdout to capture the output of the subcommand
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	// Run subcommand
+	handleDebugExternalBaselineSubcommand([]string{"debug-external-baseline", tmpDir}, "")
+
+	// Restore stdout
+	w.Close()
+	os.Stdout = oldStdout
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	output := buf.String()
+
+	// Verify stdout contains the summary of loaded baseline files
+	if !strings.Contains(output, "Summary of loaded baseline files:") {
+		t.Errorf("Expected output to contain summary title, got:\n%s", output)
+	}
+
+	// Verify it contains the path of package1 baseline translation
+	expectedP1 := filepath.Join("vendor", "acme", "package1", "src/Service1.php")
+	if !strings.Contains(output, expectedP1) {
+		t.Errorf("Expected output to contain package1 relative path %q, got:\n%s", expectedP1, output)
+	}
+
+	// Verify it contains package2 path translation
+	expectedP2 := filepath.Join("vendor", "acme", "package2", "src/Service2.php")
+	if !strings.Contains(output, expectedP2) {
+		t.Errorf("Expected output to contain package2 relative path %q, got:\n%s", expectedP2, output)
+	}
+
+	// Verify it contains the reason for package1 on a separate indented line
+	expectedReason := "           ◦ Reason: Legacy code needing refactor"
+	if !strings.Contains(output, expectedReason) {
+		t.Errorf("Expected output to contain package1 reason %q, got:\n%s", expectedReason, output)
 	}
 }

--- a/cmd/igor/main.go
+++ b/cmd/igor/main.go
@@ -36,7 +36,7 @@ func main() {
 	aud.Symfony = detectSymfonyProject(rootPath, cfg)
 
 	// 3. Load Baseline
-	baseline := loadAuditBaseline(rootPath, cfg)
+	baseline := loadAuditBaseline(rootPath, &cfg)
 
 	// 4. Collect Files to Audit
 	auditList := collectFiles(rootPath, cfg, aud)
@@ -128,7 +128,7 @@ func detectSymfonyProject(rootPath string, cfg config.Config) *auditor.SymfonyBr
 	return sb
 }
 
-func loadAuditBaseline(rootPath string, cfg config.Config) config.Baseline {
+func loadAuditBaseline(rootPath string, cfg *config.Config) config.Baseline {
 	if cfg.GenerateBaseline {
 		return config.Baseline{}
 	}
@@ -151,23 +151,32 @@ func loadAuditBaseline(rootPath string, cfg config.Config) config.Baseline {
 		}
 	}
 
-	if !cfg.IgnoreExternalBaseline && !cfg.CheckBaseline && !cfg.PruneBaseline {
-		discoverAndMergeExternalBaselines(rootPath, cfg, &baseline)
-	}
+	discoverAndMergeExternalBaselines(rootPath, cfg, &baseline)
 
 	return baseline
 }
 
-func discoverAndMergeExternalBaselines(rootPath string, cfg config.Config, baseline *config.Baseline) {
+func discoverAndMergeExternalBaselines(rootPath string, cfg *config.Config, baseline *config.Baseline) {
 	vendorDir := filepath.Join(rootPath, "vendor")
 	vendors, err := os.ReadDir(vendorDir)
 	if err != nil {
 		return
 	}
 
+	if cfg.SymlinkMap == nil {
+		cfg.SymlinkMap = make(map[string]string)
+	}
+
 	externalCount := 0
 	for _, vDir := range vendors {
-		if !vDir.IsDir() {
+		isDir := vDir.IsDir()
+		if !isDir && (vDir.Type()&os.ModeSymlink != 0) {
+			path := filepath.Join(vendorDir, vDir.Name())
+			if info, err := os.Stat(path); err == nil && info.IsDir() {
+				isDir = true
+			}
+		}
+		if !isDir {
 			continue
 		}
 		vName := vDir.Name()
@@ -181,13 +190,30 @@ func discoverAndMergeExternalBaselines(rootPath string, cfg config.Config, basel
 			continue
 		}
 		for _, pDir := range pkgs {
-			if !pDir.IsDir() {
+			isPkgDir := pDir.IsDir()
+			isSymlink := pDir.Type()&os.ModeSymlink != 0
+			if !isPkgDir && isSymlink {
+				path := filepath.Join(packagesDir, pDir.Name())
+				if info, err := os.Stat(path); err == nil && info.IsDir() {
+					isPkgDir = true
+				}
+			}
+			if !isPkgDir {
 				continue
 			}
 			pName := pDir.Name()
 			packagePath := filepath.Join(packagesDir, pName)
 
-			externalCount += loadAndMergePackageBaseline(packagePath, vName, pName, cfg, baseline)
+			if isSymlink {
+				realPath, err := filepath.EvalSymlinks(packagePath)
+				if err == nil {
+					cfg.SymlinkMap[realPath] = filepath.Join("vendor", vName, pName)
+				}
+			}
+
+			if !cfg.IgnoreExternalBaseline && !cfg.CheckBaseline && !cfg.PruneBaseline {
+				externalCount += loadAndMergePackageBaseline(packagePath, vName, pName, isSymlink, *cfg, baseline)
+			}
 		}
 	}
 	if externalCount > 0 {
@@ -195,7 +221,7 @@ func discoverAndMergeExternalBaselines(rootPath string, cfg config.Config, basel
 	}
 }
 
-func loadAndMergePackageBaseline(packagePath, vName, pName string, cfg config.Config, baseline *config.Baseline) int {
+func loadAndMergePackageBaseline(packagePath, vName, pName string, isSymlink bool, cfg config.Config, baseline *config.Baseline) int {
 	configPath := filepath.Join(packagePath, "igor.json")
 	var baselinePath string
 
@@ -219,6 +245,12 @@ func loadAndMergePackageBaseline(packagePath, vName, pName string, cfg config.Co
 	if baselinePath != "" {
 		externalBaseline, err := config.LoadBaseline(baselinePath)
 		if err == nil {
+			linkType := "regular"
+			if isSymlink {
+				linkType = "symlinked"
+			}
+			fmt.Fprintf(os.Stderr, "🛡️  Found %s external baseline for package %s/%s at: %s (%d files ignored)\n", linkType, vName, pName, baselinePath, len(externalBaseline.Files))
+
 			if baseline.Files == nil {
 				baseline.Files = make(map[string][]config.BaselineEntry)
 			}
@@ -265,6 +297,7 @@ func executeAudit(auditList []symbol.AuditStatus, aud *auditor.Auditor, cfg conf
 	var finalResults []symbol.AuditStatus
 
 	for res := range resultsChan {
+		res.FilePath = cfg.NormalizePath(res.FilePath)
 		if !cfg.GenerateBaseline && !cfg.CheckBaseline && !cfg.PruneBaseline && baseline.Files != nil {
 			res.Findings = config.FilterFindings(baseline, res.FilePath, res.Findings, rootPath)
 			res.Status = calculateAuditStatus(res.Findings)
@@ -328,7 +361,8 @@ func parseFlagsAndInit() (config.Config, string, bool) {
 		fmt.Fprintf(os.Stderr, "Usage:\n")
 		fmt.Fprintf(os.Stderr, "  %s [options] <directory>    Audit a project\n", binName)
 		fmt.Fprintf(os.Stderr, "  %s init [options] [directory] Initialize a new igor.json config\n", binName)
-		fmt.Fprintf(os.Stderr, "  %s review <json_file>       Review an audit JSON export with an LLM\n\n", binName)
+		fmt.Fprintf(os.Stderr, "  %s review <json_file>       Review an audit JSON export with an LLM\n", binName)
+		fmt.Fprintf(os.Stderr, "  %s debug-external-baseline [directory] List all discovered vendor baselines in the project\n\n", binName)
 		fmt.Fprintf(os.Stderr, "Options:\n")
 		flag.PrintDefaults()
 		fmt.Fprintf(os.Stderr, "\nExamples:\n")
@@ -339,6 +373,7 @@ func parseFlagsAndInit() (config.Config, string, bool) {
 		fmt.Fprintf(os.Stderr, "  %s -c custom-igor.json .\n", binName)
 		fmt.Fprintf(os.Stderr, "  %s init\n", binName)
 		fmt.Fprintf(os.Stderr, "  %s review igor-export.json\n", binName)
+		fmt.Fprintf(os.Stderr, "  %s debug-external-baseline .\n", binName)
 		fmt.Fprintf(os.Stderr, "  %s --env stage --verbose ./my-project\n", binName)
 	}
 
@@ -357,6 +392,9 @@ func parseFlagsAndInit() (config.Config, string, bool) {
 			return config.Config{}, "", true
 		case "review":
 			handleReviewSubcommand(args, configPath)
+			return config.Config{}, "", true
+		case "debug-external-baseline":
+			handleDebugExternalBaselineSubcommand(args, configPath)
 			return config.Config{}, "", true
 		}
 	}
@@ -509,6 +547,38 @@ func handleAPIReview(content string, cfg config.Config) {
 
 	fmt.Fprintf(os.Stderr, "✨ %s Review complete! Results saved to igor-review.md\n", modeName)
 	os.Exit(0)
+}
+
+func handleDebugExternalBaselineSubcommand(args []string, configPath string) {
+	targetDir := "."
+	if len(args) > 1 {
+		targetDir = args[1]
+	}
+	rootPath, _ := filepath.Abs(targetDir)
+
+	cfg := config.LoadConfig(rootPath, configPath)
+	var baseline config.Baseline
+	baseline.Files = make(map[string][]config.BaselineEntry)
+
+	fmt.Fprintf(os.Stderr, "🔍 Debugging external baselines for project at: %s\n\n", rootPath)
+
+	discoverAndMergeExternalBaselines(rootPath, &cfg, &baseline)
+
+	fmt.Println("\n📋 Summary of loaded baseline files:")
+	if len(baseline.Files) == 0 {
+		fmt.Println("   No baseline files or entries found.")
+		return
+	}
+
+	for relPath, entries := range baseline.Files {
+		fmt.Printf("   - %s (%d rules ignored)\n", relPath, len(entries))
+		for _, entry := range entries {
+			fmt.Printf("       • %s\n", entry.Message)
+			if entry.Reason != "" {
+				fmt.Printf("           ◦ Reason: %s\n", entry.Reason)
+			}
+		}
+	}
 }
 
 func applyFlagOverrides(cfg *config.Config, consoleFlag, envFlag *string, verboseFlag, noAgentFlag *bool, outputFlag *string, generateBaselineFlag *bool, baselineFlag, containerDumpFlag *string, ignoreExternalBaselineFlag *bool, checkBaselineFlag, pruneBaselineFlag *bool) {

--- a/cmd/igor/main.go
+++ b/cmd/igor/main.go
@@ -184,41 +184,48 @@ func discoverAndMergeExternalBaselines(rootPath string, cfg *config.Config, base
 			continue
 		}
 
-		packagesDir := filepath.Join(vendorDir, vName)
-		pkgs, err := os.ReadDir(packagesDir)
-		if err != nil {
-			continue
-		}
-		for _, pDir := range pkgs {
-			isPkgDir := pDir.IsDir()
-			isSymlink := pDir.Type()&os.ModeSymlink != 0
-			if !isPkgDir && isSymlink {
-				path := filepath.Join(packagesDir, pDir.Name())
-				if info, err := os.Stat(path); err == nil && info.IsDir() {
-					isPkgDir = true
-				}
-			}
-			if !isPkgDir {
-				continue
-			}
-			pName := pDir.Name()
-			packagePath := filepath.Join(packagesDir, pName)
-
-			if isSymlink {
-				realPath, err := filepath.EvalSymlinks(packagePath)
-				if err == nil {
-					cfg.SymlinkMap[realPath] = filepath.Join("vendor", vName, pName)
-				}
-			}
-
-			if !cfg.IgnoreExternalBaseline && !cfg.CheckBaseline && !cfg.PruneBaseline {
-				externalCount += loadAndMergePackageBaseline(packagePath, vName, pName, isSymlink, *cfg, baseline)
-			}
-		}
+		externalCount += discoverVendorPackages(vendorDir, vName, cfg, baseline)
 	}
 	if externalCount > 0 {
 		fmt.Fprintf(os.Stderr, "🛡️  Loaded %d external baseline paths from vendor dependencies.\n", externalCount)
 	}
+}
+
+func discoverVendorPackages(vendorDir, vName string, cfg *config.Config, baseline *config.Baseline) int {
+	packagesDir := filepath.Join(vendorDir, vName)
+	pkgs, err := os.ReadDir(packagesDir)
+	if err != nil {
+		return 0
+	}
+
+	count := 0
+	for _, pDir := range pkgs {
+		isPkgDir := pDir.IsDir()
+		isSymlink := pDir.Type()&os.ModeSymlink != 0
+		if !isPkgDir && isSymlink {
+			path := filepath.Join(packagesDir, pDir.Name())
+			if info, err := os.Stat(path); err == nil && info.IsDir() {
+				isPkgDir = true
+			}
+		}
+		if !isPkgDir {
+			continue
+		}
+		pName := pDir.Name()
+		packagePath := filepath.Join(packagesDir, pName)
+
+		if isSymlink {
+			realPath, err := filepath.EvalSymlinks(packagePath)
+			if err == nil {
+				cfg.SymlinkMap[realPath] = filepath.Join("vendor", vName, pName)
+			}
+		}
+
+		if !cfg.IgnoreExternalBaseline && !cfg.CheckBaseline && !cfg.PruneBaseline {
+			count += loadAndMergePackageBaseline(packagePath, vName, pName, isSymlink, *cfg, baseline)
+		}
+	}
+	return count
 }
 
 func loadAndMergePackageBaseline(packagePath, vName, pName string, isSymlink bool, cfg config.Config, baseline *config.Baseline) int {

--- a/internal/config/models.go
+++ b/internal/config/models.go
@@ -1,25 +1,49 @@
 package config
 
+import (
+	"path/filepath"
+	"strings"
+)
+
 // Config stores linter settings.
 type Config struct {
-	Exclude                []string  `json:"exclude"`
-	SafeNamespaces         []string  `json:"safe_namespaces"`
-	ScanVendors            []string  `json:"scan_vendors"`
-	IgnoreVendors          bool      `json:"ignore_vendors"`
-	IgnoreExternalBaseline bool      `json:"ignore_external_baseline"`
-	ConsolePath            string    `json:"console_path"`
-	Env                    string    `json:"env"`
-	Verbose                bool      `json:"verbose"`
-	BaselinePath           string    `json:"baseline"`
-	NoAgent                bool      `json:"-"` // Skip Igor Agent even if available
-	ProdPackages           []string  `json:"-"` // List of require packages from composer.json
-	DevPackages            []string  `json:"-"` // List of require-dev packages from composer.json
-	GenerateBaseline       bool      `json:"-"` // Internal: set if --generate-baseline is used
-	CheckBaseline          bool      `json:"-"` // Internal: set if --check-baseline is used
-	PruneBaseline          bool      `json:"-"` // Internal: set if --prune-baseline is used
-	OutputFormat           string    `json:"output"`
-	ContainerDump          string    `json:"container_dump"` // Path to a generic container dump (framework-agnostic non-shared service graph)
-	LLMConfig              LLMConfig `json:"llm"`
+	Exclude                []string          `json:"exclude"`
+	SafeNamespaces         []string          `json:"safe_namespaces"`
+	ScanVendors            []string          `json:"scan_vendors"`
+	IgnoreVendors          bool              `json:"ignore_vendors"`
+	IgnoreExternalBaseline bool              `json:"ignore_external_baseline"`
+	ConsolePath            string            `json:"console_path"`
+	Env                    string            `json:"env"`
+	Verbose                bool              `json:"verbose"`
+	BaselinePath           string            `json:"baseline"`
+	NoAgent                bool              `json:"-"` // Skip Igor Agent even if available
+	ProdPackages           []string          `json:"-"` // List of require packages from composer.json
+	DevPackages            []string          `json:"-"` // List of require-dev packages from composer.json
+	GenerateBaseline       bool              `json:"-"` // Internal: set if --generate-baseline is used
+	CheckBaseline          bool              `json:"-"` // Internal: set if --check-baseline is used
+	PruneBaseline          bool              `json:"-"` // Internal: set if --prune-baseline is used
+	OutputFormat           string            `json:"output"`
+	ContainerDump          string            `json:"container_dump"` // Path to a generic container dump (framework-agnostic non-shared service graph)
+	LLMConfig              LLMConfig         `json:"llm"`
+	SymlinkMap             map[string]string `json:"-"` // Maps real path of symlinked vendors to their vendor-relative paths
+}
+
+// NormalizePath translates a physical path (which may be a resolved symlink)
+// back into its corresponding vendor-relative path if it belongs to a symlinked vendor package.
+func (c Config) NormalizePath(filePath string) string {
+	if c.SymlinkMap == nil {
+		return filePath
+	}
+	cleaned := filepath.Clean(filePath)
+	for realPath, symlinkedPath := range c.SymlinkMap {
+		if strings.HasPrefix(cleaned, realPath) {
+			rel, err := filepath.Rel(realPath, cleaned)
+			if err == nil {
+				return filepath.Join(symlinkedPath, rel)
+			}
+		}
+	}
+	return filePath
 }
 
 // LLMConfig stores settings for LLM-based review.


### PR DESCRIPTION
## Context

[*Fixes a bug where external baselines for symlinked vendor packages are ignored.*](https://github.com/igor-php/igor-php/issues/66)

When developing with local bundles linked via Composer's `path` repository (which creates a symlink in `vendor/`), Igor was unable to load and apply their baselines. This was caused by two issues:
1. Go's `os.ReadDir` skips symlinks when checking `.IsDir()`, preventing the baseline auto-discovery from scanning the symlinked package.
2. PHP Reflection (`ReflectionClass::getFileName()`) resolves symlinks to their absolute physical paths, which breaks the relative path matching used by the baseline dictionary (e.g., matching `/path/to/my-bundle/src/Service.php` against `vendor/acme/my-bundle/src/Service.php`).

Additionally, to improve visibility into how external baselines are loaded and merged, this PR introduces a new `debug-external-baseline` subcommand.

## Implementation

- **Symlink Auto-Discovery**: Updated `discoverAndMergeExternalBaselines` in `cmd/igor/main.go` to explicitly check for `os.ModeSymlink` and resolve the target using `os.Stat()` to ensure symlinked directories are scanned.
- **Path Normalization**: Added a `SymlinkMap` to `config.Config` (`internal/config/models.go`) that stores the mapping between the absolute physical path of a symlinked package and its logical vendor path. The `NormalizePath` method is now called during the audit loop to transparently convert PHP reflection realpaths back to their `vendor/...` format before checking the baseline.
- **Discovery Logging**: Enhanced the discovery logs to clearly specify if a loaded vendor baseline is `regular` or `symlinked`.
- **Debug Subcommand**: Added `igor-php debug-external-baseline .` which prints a detailed summary of all loaded vendor baseline files, the rules being ignored, and their associated `Reason` (rendered with a clean, indented sub-bullet).
- **Tests**: Added comprehensive integration tests in `cmd/igor/external_baseline_test.go` to verify symlink path normalization (including handling macOS `/var` vs `/private/var` temp directory symlinks) and to validate the debug subcommand's output formatting.

## Requirements

- [x] I have performed a self code-review.
- [x] I have added / updated unit and integration tests to verify my changes.
- [x] I have updated the documentation / README if applicable.
- [x] I have run local CI checks (`make ci` / `go test`) and all checks passed.
- [x] I have performed manual tests to ensure the changes work as intended.

## Documentations

- Updated `README.md`: Added documentation for **Symlink Support** under the External Vendor Baselines section.
- Updated `README.md`: Added a new section **🔍 Debugging Discovered External Baselines** detailing the usage and output of the new debug subcommand.

## Manual tests

- **Test Case:** Run `igor-php debug-external-baseline .` on a project containing a symlinked local bundle with a custom baseline containing `reason` fields.
- **Observed Result:** The CLI correctly reports `🛡️ Found symlinked external baseline for package...` and prints the summary tree with the ignored rules and their neatly indented `◦ Reason: ...` fields.
- **Test Case:** Run standard `igor-php .` on the same project with known violations in the symlinked bundle.
- **Observed Result:** The violations in the symlinked bundle are successfully filtered out by the merged external baseline, proving the path normalization works correctly.

## Performance tests (optional)

*N/A - The path normalization uses a fast prefix string match loop on a very small map (only containing entries for symlinked vendor packages).*

## Screenshots (optional)

**Debug Command Output:**
```text
🔍 Debugging external baselines for project at: /Users/thomas/projects/my-project

🛡️  Found regular external baseline for package acme/package1 at: [...] (1 files ignored)
🛡️  Found symlinked external baseline for package acme/package3 at: [...] (1 files ignored)
🛡️  Loaded 2 external baseline paths from vendor dependencies.

📋 Summary of loaded baseline files:
   - vendor/acme/package1/src/Service1.php (1 rules ignored)
       • State mutation detected in Service1
           ◦ Reason: Legacy code needing refactor
```