### PR TITLE
FEAT: Implement Doctrine EM reset delegation and lifecycle whitelist …

### DIFF
--- a/internal/analyzer/visitor.go
+++ b/internal/analyzer/visitor.go
@@ -705,7 +705,16 @@ func (v *PHPVisitor) detectSingletonMutation(n *sitter.Node, propName, methodNam
 	if typeName, ok := v.propertyTypes[propName]; ok {
 		fqcn := v.resolveFQCN(typeName)
 		if v.engine != nil && v.engine.IsResettable(fqcn) {
-			isResettable = true
+			if isDoctrineManager(fqcn) {
+				obj := n.ChildByFieldName("object")
+				if obj != nil && v.isDirectReference(obj) && isUnitOfWorkLifecycleMethod(methodName) {
+					isResettable = true
+				} else {
+					isResettable = false
+				}
+			} else {
+				isResettable = true
+			}
 		}
 	}
 
@@ -746,6 +755,40 @@ func (v *PHPVisitor) detectClosureStateLeak(n *sitter.Node) {
 		}
 	}
 	findClosures(argsNode)
+}
+
+func isDoctrineManager(className string) bool {
+	normalized := strings.ReplaceAll(className, "/", "\\")
+	normalized = strings.TrimPrefix(normalized, "\\")
+	lower := strings.ToLower(normalized)
+	return strings.Contains(lower, "doctrine\\orm\\entitymanager") ||
+		strings.Contains(lower, "doctrine\\persistence\\objectmanager") ||
+		strings.Contains(lower, "doctrine\\odm\\mongodb\\documentmanager")
+}
+
+func isUnitOfWorkLifecycleMethod(methodName string) bool {
+	switch methodName {
+	case "persist", "remove", "flush", "clear", "refresh", "detach", "merge":
+		return true
+	}
+	return false
+}
+
+func (v *PHPVisitor) isDirectReference(n *sitter.Node) bool {
+	if n == nil {
+		return false
+	}
+	if _, ok := v.isPropertyFetchOnThis(n); ok {
+		return true
+	}
+	kind := n.Kind()
+	if kind == "variable" || kind == "variable_name" {
+		content := v.getContent(n)
+		if strings.HasPrefix(content, "$") && v.localSharedVars[content] {
+			return true
+		}
+	}
+	return false
 }
 
 // isPropertyFetchOnThis checks if a node is a property of the current class via $this (e.g., $this->propertyName)

--- a/internal/analyzer/visitor_test.go
+++ b/internal/analyzer/visitor_test.go
@@ -27,6 +27,12 @@ func (m *mockEngine) IsSafeNamespace(_ string) bool {
 }
 
 func (m *mockEngine) IsResettable(className string) bool {
+	lower := strings.ToLower(className)
+	if strings.Contains(lower, "doctrine\\orm\\entitymanager") ||
+		strings.Contains(lower, "doctrine\\persistence\\objectmanager") ||
+		strings.Contains(lower, "doctrine\\odm\\mongodb\\documentmanager") {
+		return true
+	}
 	return className == "Xynnn\\GoogleTagManagerBundle\\Service\\GoogleTagManagerInterface" || className == "App\\Service\\ResettableService"
 }
 
@@ -907,4 +913,70 @@ func TestPHPVisitor_EdgeCases(t *testing.T) {
 		// A non-function-call node passed to handleFunctionCall should just return safely
 		v.handleFunctionCall(tree.RootNode())
 	})
+}
+
+func TestPHPVisitor_DoctrineEntityManager_Lifecycle(t *testing.T) {
+	code := `<?php
+class DoctrineService {
+    private \Doctrine\ORM\EntityManagerInterface $em;
+
+    public function __construct(\Doctrine\ORM\EntityManagerInterface $em) {
+        $this->em = $em;
+    }
+
+    public function testRemove($product) {
+        $this->em->remove($product); // Safe, whitelisted direct call
+    }
+
+    public function testClear() {
+        $this->em->clear(); // Safe, whitelisted direct call
+    }
+
+    public function testSetConfiguration($config) {
+        $this->em->setConfiguration($config); // Unsafe: direct call but NOT on UnitOfWork whitelist
+    }
+
+    public function testChainedDisable() {
+        $this->em->getFilters()->disable('softdeleteable'); // Unsafe: chained mutation call
+    }
+}`
+	content := []byte(code)
+
+	p := sitter.NewParser()
+	lang := sitter.NewLanguage(php.LanguagePHP())
+	_ = p.SetLanguage(lang)
+	tree := p.Parse(content, nil)
+	defer tree.Close()
+
+	engine := &mockEngine{}
+	v := NewVisitor(content, engine)
+	v.Walk(tree.RootNode())
+
+	findings := v.Findings()
+
+	// We expect exactly 2 findings:
+	// 1 for setConfiguration
+	// 1 for disable ('softdeleteable') called in a chained way
+	if len(findings) != 2 {
+		t.Fatalf("Expected exactly 2 findings, got %d: %v", len(findings), findings)
+	}
+
+	foundSetConfiguration := false
+	foundChainedDisable := false
+
+	for _, f := range findings {
+		if strings.Contains(f.Snippet, "setConfiguration") {
+			foundSetConfiguration = true
+		}
+		if strings.Contains(f.Snippet, "disable") {
+			foundChainedDisable = true
+		}
+	}
+
+	if !foundSetConfiguration {
+		t.Error("Expected a finding for setConfiguration on EntityManager")
+	}
+	if !foundChainedDisable {
+		t.Error("Expected a finding for chained disable call on EntityManager filters")
+	}
 }

--- a/internal/auditor/auditor.go
+++ b/internal/auditor/auditor.go
@@ -219,6 +219,27 @@ func (a *Auditor) IsResettable(className string) bool {
 	}
 	possibleIDs := a.resolveAliases(className)
 
+	// Check if any of possibleIDs corresponds to a Doctrine Manager
+	isDoctrine := false
+	for _, id := range possibleIDs {
+		lower := strings.ToLower(id)
+		if strings.Contains(lower, "doctrine\\orm\\entitymanager") ||
+			strings.Contains(lower, "doctrine\\persistence\\objectmanager") ||
+			strings.Contains(lower, "doctrine\\odm\\mongodb\\documentmanager") {
+			isDoctrine = true
+			break
+		}
+	}
+
+	if isDoctrine {
+		if def, exists := a.Symfony.Container.Definitions["doctrine"]; exists && def.IsResettable() {
+			return true
+		}
+		if def, exists := a.Symfony.Container.Definitions["doctrine_mongodb"]; exists && def.IsResettable() {
+			return true
+		}
+	}
+
 	for defID, def := range a.Symfony.Container.Definitions {
 		normDefID := normalizeClassName(defID)
 		normDefClass := normalizeClassName(def.Class)

--- a/internal/auditor/service_auditor_test.go
+++ b/internal/auditor/service_auditor_test.go
@@ -233,6 +233,79 @@ func TestAuditor_IsResettable_And_IsExplicitlyNonShared(t *testing.T) {
 	})
 }
 
+func TestAuditor_IsResettable_DoctrineManager(t *testing.T) {
+	// Case 1: doctrine is resettable
+	{
+		a := NewAuditor(config.Config{})
+		a.Symfony = &SymfonyBridge{
+			Container: &symbol.SymfonyContainer{
+				Definitions: map[string]symbol.SymfonyService{
+					"doctrine": {
+						Class:      "Doctrine\\Bundle\\DoctrineBundle\\Registry",
+						Resettable: true,
+					},
+				},
+			},
+		}
+
+		if !a.IsResettable("Doctrine\\ORM\\EntityManagerInterface") {
+			t.Error("Expected EntityManagerInterface to be resettable when 'doctrine' service is resettable")
+		}
+	}
+
+	// Case 2: doctrine is NOT resettable
+	{
+		a := NewAuditor(config.Config{})
+		a.Symfony = &SymfonyBridge{
+			Container: &symbol.SymfonyContainer{
+				Definitions: map[string]symbol.SymfonyService{
+					"doctrine": {
+						Class:      "Doctrine\\Bundle\\DoctrineBundle\\Registry",
+						Resettable: false,
+					},
+				},
+			},
+		}
+
+		if a.IsResettable("Doctrine\\ORM\\EntityManagerInterface") {
+			t.Error("Expected EntityManagerInterface to NOT be resettable when 'doctrine' service is NOT resettable")
+		}
+	}
+
+	// Case 3: doctrine_mongodb is resettable
+	{
+		a := NewAuditor(config.Config{})
+		a.Symfony = &SymfonyBridge{
+			Container: &symbol.SymfonyContainer{
+				Definitions: map[string]symbol.SymfonyService{
+					"doctrine_mongodb": {
+						Class:      "Doctrine\\Bundle\\MongoDBBundle\\ManagerRegistry",
+						Resettable: true,
+					},
+				},
+			},
+		}
+
+		if !a.IsResettable("Doctrine\\ODM\\MongoDB\\DocumentManager") {
+			t.Error("Expected DocumentManager to be resettable when 'doctrine_mongodb' service is resettable")
+		}
+	}
+
+	// Case 4: No doctrine registry service defined
+	{
+		a := NewAuditor(config.Config{})
+		a.Symfony = &SymfonyBridge{
+			Container: &symbol.SymfonyContainer{
+				Definitions: map[string]symbol.SymfonyService{},
+			},
+		}
+
+		if a.IsResettable("Doctrine\\ORM\\EntityManagerInterface") {
+			t.Error("Expected EntityManagerInterface to NOT be resettable when no registry is defined")
+		}
+	}
+}
+
 func TestAuditor_HelperMethods(t *testing.T) {
 	cfg := config.Config{
 		DevPackages:    []string{"phpunit/phpunit", "friendsofphp/php-cs-fixer"},


### PR DESCRIPTION

- Add Symfony reset delegation check in IsResettable for Doctrine managers.
- Implement UnitOfWork lifecycle method whitelist for direct EntityManager calls.
- Add unit and integration tests to verify the behavior and prevent regressions.

## Context

Issue (#59)

## Implementation

*Explain how you resolved the issue or implemented the feature. Share any architectural decisions, additions, or modifications.*

## Requirements

*Please ensure that your PR is ready by checking the appropriate boxes. If an action is not applicable (e.g., configuration changes), you can mark it as checked or note it as N/A.*

- [ ] I have performed a self code-review.
- [ ] I have added / updated unit and integration tests to verify my changes.
- [ ] I have updated the documentation / README if applicable.
- [ ] I have run local CI checks (`make ci`) and all checks passed.
- [ ] I have performed manual tests to ensure the changes work as intended.

## Documentations

*Add links to updated documentation if applicable.*

## Manual tests

*Describe the manual tests you performed in addition to automated tests to verify your implementation (this helps reviewers verify your work).*

- **Test Case:**
- **Observed Result:**

## Performance tests (optional)

*If this PR introduces major AST parsing or auditing logic changes, share any benchmark or execution time results.*

## Screenshots (optional)

*Add screenshots or terminal recordings/GIFs if this PR introduces visual or formatting changes to the command-line output.*
