### PR TITLE
feat(analyzer): rank mutator findings by call-site reachability

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ Not every flagged mutator matters equally: a setter on a vendor class might neve
   275 | $this->binary = $binary;
 ```
 
-> 💡 **Known limitation**: reachability matching works on exact `Class::Method` pairs, so it doesn't currently follow interface/inheritance chains (a subclass that inherits, but doesn't override, a flagged parent method won't be linked through). Treat `[INFO]` as "no call site found *with this analysis*", not an absolute guarantee of dead code.
+> 💡 **Known limitation**: reachability matching works on exact `Class::Method` pairs. Igor conservatively follows direct and multi-level `extends` chains — a subclass that inherits, but doesn't override, a flagged parent method is linked through to the parent's finding, and an override correctly stops that promotion at the overriding class. It does **not** follow interfaces, traits, or magic methods (`__call`, `__get`, etc.), so a call resolved only through one of those still won't be linked through. Treat `[INFO]` as "no call site found *with this analysis*", not an absolute guarantee of dead code.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Like the legendary assistant, `igor` checks every connection and part of your ap
 - **🛡️ Safety First**: Catches dangerous `exit()` or `die()` calls, and warns about **PHP Superglobals** (`$_GET`, `$_POST`, etc.) or **local static variables** that could leak state between requests.
 - **🔇 Zero Noise**: Automatically ignores `Symfony\` and `Doctrine\` namespaces, and common data folders (`Entity`, `Dto`, `ApiResource`).
 - **📦 Project vs. Vendor**: Clear separation between your code and third-party dependencies, with tailored recommendations for each.
+- **🎯 Reachability Ranking**: Cross-references every flagged mutator against your own call graph. Findings actually reachable from your application code are tagged `[HIGH]` and surface first; findings with no call site found are tagged `[INFO]`.
 - **🎯 Selective Ignore**: Skip specific lines using the `// @igor-ignore` comment, or target entire classes, methods, and properties using modern **PHP 8 Attributes** (`#[WorkerSafe]`).
 - Bridge-Agnostic Bridge**: Not on Symfony? Feed Igor your container's service graph via `--container-dump <file.json>` so it skips transient (non-shared) value objects and per-request helpers — the same precision the Symfony bridge gives, for **any** framework (Laravel, Laminas, …).
 
@@ -347,6 +348,24 @@ To prevent false positives on ephemeral objects (like OpenTelemetry Spans or Tra
   - If the type is **NOT** a shared service (e.g., `Span`), Igor classifies it as a **transient/ephemeral object**.
   - Subsequent mutations on this variable (e.g., `$span->setAttribute('key', 'value')`) are deemed **100% safe** and bypassed, ensuring zero false positives on safe request-scoped data.
   - If the return type is indeed a shared service (e.g., a shared `EntityManager`), mutations remain strictly protected.
+
+### 4. Call-Site Reachability Ranking
+Not every flagged mutator matters equally: a setter on a vendor class might never be called anywhere in your application, while another is hit on every request. Igor ranks findings accordingly:
+
+- **Call-Graph Construction**: While auditing each file, Igor records a call-graph edge for every method call whose receiver resolves to a known class — including `$this->service->method()` chains and internal `$this->otherMethod()` self-calls.
+- **BFS from Application Code**: Igor walks this graph starting from every method declared in your own project files (not `vendor/`), following calls transitively (e.g. `Controller::action()` → `Service::doWork()` → `VendorClass::mutate()`).
+- **Ranking**: Each finding is tagged `[HIGH]` if its method is reachable from this walk, or `[INFO]` if no call site was found anywhere in the audited codebase. `[HIGH]` findings are printed first within each file so the actionable bugs surface before the noise.
+
+```text
+📂 vendor/knp/snappy/src/Knp/Snappy/AbstractGenerator.php
+  [VENDOR] [HIGH] Mutation of state 'temporaryFiles' in AbstractGenerator::createTemporaryFile()
+  513 | $this->temporaryFiles[] = $filename;
+
+  [VENDOR] [INFO] Mutation of state 'binary' in AbstractGenerator::setBinary()
+  275 | $this->binary = $binary;
+```
+
+> 💡 **Known limitation**: reachability matching works on exact `Class::Method` pairs, so it doesn't currently follow interface/inheritance chains (a subclass that inherits, but doesn't override, a flagged parent method won't be linked through). Treat `[INFO]` as "no call site found *with this analysis*", not an absolute guarantee of dead code.
 
 ---
 

--- a/cmd/igor/main.go
+++ b/cmd/igor/main.go
@@ -51,6 +51,9 @@ func main() {
 	// 6. Run Audit
 	results := executeAudit(auditList, aud, cfg, baseline, rootPath)
 
+	// 6b. Rank findings by call-site reachability from application code
+	aud.MarkReachability(results)
+
 	// 7a. Handle Baseline Checking
 	if cfg.CheckBaseline {
 		staleEntries := config.IdentifyStaleEntries(baseline, results, rootPath)

--- a/internal/analyzer/visitor.go
+++ b/internal/analyzer/visitor.go
@@ -16,6 +16,7 @@ type Engine interface {
 	IsResettable(className string) bool
 	GetMethodReturnType(className, methodName string) string
 	IsSharedService(className string) bool
+	RecordMethodCall(callerClass, callerMethod, calleeClass, calleeMethod string)
 }
 
 type mutationInfo struct {
@@ -511,6 +512,13 @@ func (v *PHPVisitor) resolveReceiverType(n *sitter.Node) string {
 	// Case 2: variable, e.g. $tracer
 	if kind == "variable" || kind == "variable_name" {
 		content := v.getContent(n)
+		if content == "$this" {
+			fullName := v.curClass
+			if v.namespace != "" {
+				fullName = v.namespace + "\\" + v.curClass
+			}
+			return fullName
+		}
 		if typeName, exists := v.localVarTypes[content]; exists {
 			return v.resolveFQCN(typeName)
 		}
@@ -592,6 +600,11 @@ func (v *PHPVisitor) logMutation(n *sitter.Node, prop string, static bool) {
 }
 
 func (v *PHPVisitor) performResetCheck() {
+	fullName := v.curClass
+	if v.namespace != "" {
+		fullName = v.namespace + "\\" + v.curClass
+	}
+
 	for prop, info := range v.mutated {
 		if v.workerSafeProps[prop] {
 			continue
@@ -605,14 +618,16 @@ func (v *PHPVisitor) performResetCheck() {
 		}
 		if !v.resetted[prop] {
 			v.findings = append(v.findings, symbol.Finding{
-				Message:      fmt.Sprintf("Property '%s' of %s is mutated but not reset in reset().", prop, v.curClass),
-				Severity:     "WARNING",
-				Line:         info.line,
-				Code:         info.code,
-				Snippet:      info.snippet,
-				ASTDetails:   info.astDetails,
-				Dependencies: v.dependencies,
-				Remediation:  fmt.Sprintf("Add '$this->%s = ...' in the reset() method.", prop),
+				Message:       fmt.Sprintf("Property '%s' of %s is mutated but not reset in reset().", prop, v.curClass),
+				Severity:      "WARNING",
+				Line:          info.line,
+				Code:          info.code,
+				Snippet:       info.snippet,
+				ASTDetails:    info.astDetails,
+				Dependencies:  v.dependencies,
+				Remediation:   fmt.Sprintf("Add '$this->%s = ...' in the reset() method.", prop),
+				ContextClass:  fullName,
+				ContextMethod: v.curMethod,
 			})
 		}
 	}
@@ -643,14 +658,16 @@ func (v *PHPVisitor) addFinding(n *sitter.Node, msg, hint, severity string) {
 	}
 
 	v.findings = append(v.findings, symbol.Finding{
-		Message:      msg,
-		Line:         row + 1,
-		Code:         v.lines[row],
-		Snippet:      v.getContent(n),
-		ASTDetails:   n.ToSexp(),
-		Dependencies: v.dependencies,
-		Remediation:  hint,
-		Severity:     severity,
+		Message:       msg,
+		Line:          row + 1,
+		Code:          v.lines[row],
+		Snippet:       v.getContent(n),
+		ASTDetails:    n.ToSexp(),
+		Dependencies:  v.dependencies,
+		Remediation:   hint,
+		Severity:      severity,
+		ContextClass:  fullName,
+		ContextMethod: v.curMethod,
 	})
 }
 
@@ -732,6 +749,12 @@ func (v *PHPVisitor) handleMethodCall(n *sitter.Node) {
 		return
 	}
 	methodName := v.getContent(nameNode)
+
+	if v.engine != nil {
+		if receiverClass := v.resolveReceiverType(obj); receiverClass != "" {
+			v.engine.RecordMethodCall(fullName, v.curMethod, receiverClass, methodName)
+		}
+	}
 
 	// 2. Check if the object/chain starts with a property of the current class ($this->propertyName)
 	propName, isProp := v.resolveRootProperty(obj)

--- a/internal/analyzer/visitor.go
+++ b/internal/analyzer/visitor.go
@@ -112,13 +112,7 @@ func (v *PHPVisitor) walk(n *sitter.Node) {
 		v.finallyCleaned = make(map[string]bool)
 		v.localSharedVars = make(map[string]bool)
 		v.preScanFinallyCleanups(n)
-		if nodeType == "method_declaration" && v.curClass != "" && v.curMethod != "" && v.engine != nil {
-			fullName := v.curClass
-			if v.namespace != "" {
-				fullName = v.namespace + "\\" + v.curClass
-			}
-			v.engine.RecordMethodDeclared(fullName, v.curMethod)
-		}
+		v.recordMethodDeclaration(nodeType)
 	case "assignment_expression", "augmented_assignment_expression":
 		v.handleAssignment(n)
 	case "update_expression":
@@ -150,6 +144,18 @@ func (v *PHPVisitor) walk(n *sitter.Node) {
 	case "method_declaration", "function_definition":
 		v.curMethod, v.isWorkerSafeMethod, v.finallyCleaned = oldMethod, oldIsWorkerSafeMethod, oldFinallyCleaned
 	}
+}
+
+func (v *PHPVisitor) recordMethodDeclaration(nodeType string) {
+	if nodeType != "method_declaration" || v.curClass == "" || v.curMethod == "" || v.engine == nil {
+		return
+	}
+
+	fullName := v.curClass
+	if v.namespace != "" {
+		fullName = v.namespace + "\\" + v.curClass
+	}
+	v.engine.RecordMethodDeclared(fullName, v.curMethod)
 }
 
 func (v *PHPVisitor) handleNamespace(n *sitter.Node) {

--- a/internal/analyzer/visitor.go
+++ b/internal/analyzer/visitor.go
@@ -17,6 +17,14 @@ type Engine interface {
 	GetMethodReturnType(className, methodName string) string
 	IsSharedService(className string) bool
 	RecordMethodCall(callerClass, callerMethod, calleeClass, calleeMethod string)
+	// RecordClassParent records a direct `extends` relationship for a real class
+	// declaration (className extends parentClassName), used to conservatively
+	// resolve inherited-method reachability.
+	RecordClassParent(className, parentClassName string)
+	// RecordMethodDeclared records that methodName is directly declared on
+	// className, so the auditor can tell an inherited method apart from an
+	// override when walking the parent chain.
+	RecordMethodDeclared(className, methodName string)
 }
 
 type mutationInfo struct {
@@ -110,6 +118,13 @@ func (v *PHPVisitor) walk(n *sitter.Node) {
 		v.finallyCleaned = make(map[string]bool)
 		v.localSharedVars = make(map[string]bool)
 		v.preScanFinallyCleanups(n)
+		if nodeType == "method_declaration" && v.curClass != "" && v.curMethod != "" && v.engine != nil {
+			fullName := v.curClass
+			if v.namespace != "" {
+				fullName = v.namespace + "\\" + v.curClass
+			}
+			v.engine.RecordMethodDeclared(fullName, v.curMethod)
+		}
 	case "assignment_expression", "augmented_assignment_expression":
 		v.handleAssignment(n)
 	case "update_expression":
@@ -165,6 +180,10 @@ func (v *PHPVisitor) handleClass(n *sitter.Node) {
 		v.engine.RecordClassAudited(fullName)
 	}
 
+	if n.Kind() == "class_declaration" {
+		v.recordClassParent(n, fullName)
+	}
+
 	classText := strings.ToLower(string(v.content[n.StartByte():n.EndByte()]))
 	headerEnd := strings.Index(classText, "{")
 	if headerEnd == -1 {
@@ -190,6 +209,25 @@ func (v *PHPVisitor) handleClass(n *sitter.Node) {
 
 	v.scanReadonlyProps(n)
 	v.scanPropertyTypes(n)
+}
+
+// recordClassParent extracts the single `extends` target from a class_declaration's
+// base_clause child (if any) and reports it to the engine, resolving the name
+// through the same use-import/namespace logic as property type-hints.
+func (v *PHPVisitor) recordClassParent(n *sitter.Node, fullName string) {
+	if v.engine == nil {
+		return
+	}
+	for i := uint(0); i < n.ChildCount(); i++ {
+		child := n.Child(i)
+		if child.Kind() != "base_clause" {
+			continue
+		}
+		if nameNode := child.NamedChild(0); nameNode != nil {
+			v.engine.RecordClassParent(fullName, v.resolveFQCN(v.getContent(nameNode)))
+		}
+		return
+	}
 }
 
 func (v *PHPVisitor) getClassBody(classNode *sitter.Node) *sitter.Node {

--- a/internal/analyzer/visitor.go
+++ b/internal/analyzer/visitor.go
@@ -17,13 +17,7 @@ type Engine interface {
 	GetMethodReturnType(className, methodName string) string
 	IsSharedService(className string) bool
 	RecordMethodCall(callerClass, callerMethod, calleeClass, calleeMethod string)
-	// RecordClassParent records a direct `extends` relationship for a real class
-	// declaration (className extends parentClassName), used to conservatively
-	// resolve inherited-method reachability.
 	RecordClassParent(className, parentClassName string)
-	// RecordMethodDeclared records that methodName is directly declared on
-	// className, so the auditor can tell an inherited method apart from an
-	// override when walking the parent chain.
 	RecordMethodDeclared(className, methodName string)
 }
 

--- a/internal/analyzer/visitor.go
+++ b/internal/analyzer/visitor.go
@@ -730,14 +730,6 @@ func (v *PHPVisitor) handleMethodCall(n *sitter.Node) {
 		fullName = v.namespace + "\\" + v.curClass
 	}
 
-	// If the service is explicitly transient (non-shared), mutations are accepted
-	if v.nonSharedServices[strings.TrimPrefix(fullName, "\\")] {
-		return
-	}
-	if v.engine != nil && (v.engine.IsExplicitlyNonShared(fullName) || v.engine.IsSafeNamespace(fullName)) {
-		return
-	}
-
 	// 1. Retrieve the calling receiver object and the method name
 	obj := n.ChildByFieldName("object")
 	if obj == nil {
@@ -754,6 +746,14 @@ func (v *PHPVisitor) handleMethodCall(n *sitter.Node) {
 		if receiverClass := v.resolveReceiverType(obj); receiverClass != "" {
 			v.engine.RecordMethodCall(fullName, v.curMethod, receiverClass, methodName)
 		}
+	}
+
+	// If the service is explicitly transient (non-shared), mutations are accepted
+	if v.nonSharedServices[strings.TrimPrefix(fullName, "\\")] {
+		return
+	}
+	if v.engine != nil && (v.engine.IsExplicitlyNonShared(fullName) || v.engine.IsSafeNamespace(fullName)) {
+		return
 	}
 
 	// 2. Check if the object/chain starts with a property of the current class ($this->propertyName)

--- a/internal/analyzer/visitor_test.go
+++ b/internal/analyzer/visitor_test.go
@@ -13,6 +13,11 @@ import (
 type mockEngine struct {
 	auditedClasses    []string
 	methodReturnTypes map[string]string
+	recordedCalls     []string
+}
+
+func (m *mockEngine) RecordMethodCall(callerClass, callerMethod, calleeClass, calleeMethod string) {
+	m.recordedCalls = append(m.recordedCalls, callerClass+"::"+callerMethod+" -> "+calleeClass+"::"+calleeMethod)
 }
 
 func (m *mockEngine) RecordClassAudited(name string) {

--- a/internal/analyzer/visitor_test.go
+++ b/internal/analyzer/visitor_test.go
@@ -14,10 +14,26 @@ type mockEngine struct {
 	auditedClasses    []string
 	methodReturnTypes map[string]string
 	recordedCalls     []string
+	recordedParents   map[string]string
+	declaredMethods   map[string][]string
 }
 
 func (m *mockEngine) RecordMethodCall(callerClass, callerMethod, calleeClass, calleeMethod string) {
 	m.recordedCalls = append(m.recordedCalls, callerClass+"::"+callerMethod+" -> "+calleeClass+"::"+calleeMethod)
+}
+
+func (m *mockEngine) RecordClassParent(className, parentClassName string) {
+	if m.recordedParents == nil {
+		m.recordedParents = make(map[string]string)
+	}
+	m.recordedParents[className] = parentClassName
+}
+
+func (m *mockEngine) RecordMethodDeclared(className, methodName string) {
+	if m.declaredMethods == nil {
+		m.declaredMethods = make(map[string][]string)
+	}
+	m.declaredMethods[className] = append(m.declaredMethods[className], methodName)
 }
 
 func (m *mockEngine) RecordClassAudited(name string) {
@@ -1091,5 +1107,156 @@ class SuperService {
 
 	if !strings.Contains(findings[0].Snippet, "setSomeValue") {
 		t.Errorf("Expected finding to be on setSomeValue, got: %s", findings[0].Snippet)
+	}
+}
+
+func TestPHPVisitor_ClassInheritance_DirectExtends(t *testing.T) {
+	code := `<?php
+namespace App\Service;
+
+use Vendor\Lib\BaseService;
+
+class ChildService extends BaseService
+{
+}`
+	content := []byte(code)
+
+	p := sitter.NewParser()
+	lang := sitter.NewLanguage(php.LanguagePHP())
+	_ = p.SetLanguage(lang)
+	tree := p.Parse(content, nil)
+	defer tree.Close()
+
+	engine := &mockEngine{}
+	v := NewVisitor(content, engine)
+	v.Walk(tree.RootNode())
+
+	got := engine.recordedParents["App\\Service\\ChildService"]
+	want := "Vendor\\Lib\\BaseService"
+	if got != want {
+		t.Errorf("expected ChildService parent %q, got %q (all: %v)", want, got, engine.recordedParents)
+	}
+}
+
+func TestPHPVisitor_ClassInheritance_MultiLevel(t *testing.T) {
+	code := `<?php
+namespace App\Service;
+
+class GrandParentService
+{
+}
+
+class ParentService extends GrandParentService
+{
+}
+
+class ChildService extends ParentService
+{
+}`
+	content := []byte(code)
+
+	p := sitter.NewParser()
+	lang := sitter.NewLanguage(php.LanguagePHP())
+	_ = p.SetLanguage(lang)
+	tree := p.Parse(content, nil)
+	defer tree.Close()
+
+	engine := &mockEngine{}
+	v := NewVisitor(content, engine)
+	v.Walk(tree.RootNode())
+
+	if got := engine.recordedParents["App\\Service\\ChildService"]; got != "App\\Service\\ParentService" {
+		t.Errorf("expected ChildService parent App\\Service\\ParentService, got %q", got)
+	}
+	if got := engine.recordedParents["App\\Service\\ParentService"]; got != "App\\Service\\GrandParentService" {
+		t.Errorf("expected ParentService parent App\\Service\\GrandParentService, got %q", got)
+	}
+	if _, exists := engine.recordedParents["App\\Service\\GrandParentService"]; exists {
+		t.Errorf("expected GrandParentService to have no recorded parent, got %v", engine.recordedParents)
+	}
+}
+
+func TestPHPVisitor_ClassInheritance_NotRecordedForTraitsAnonymousOrImplementsOnly(t *testing.T) {
+	code := `<?php
+namespace App\Service;
+
+trait MyTrait
+{
+}
+
+interface MyInterface
+{
+}
+
+class ImplementsOnly implements MyInterface
+{
+}
+
+class AnonHost
+{
+    public function make()
+    {
+        return new class extends \ArrayObject {
+        };
+    }
+}`
+	content := []byte(code)
+
+	p := sitter.NewParser()
+	lang := sitter.NewLanguage(php.LanguagePHP())
+	_ = p.SetLanguage(lang)
+	tree := p.Parse(content, nil)
+	defer tree.Close()
+
+	engine := &mockEngine{}
+	v := NewVisitor(content, engine)
+	v.Walk(tree.RootNode())
+
+	if len(engine.recordedParents) != 0 {
+		t.Errorf("expected no recorded parents for trait/anonymous/implements-only classes, got %v", engine.recordedParents)
+	}
+}
+
+func TestPHPVisitor_MethodDeclared_OnlyClassMethodsNotFreeFunctions(t *testing.T) {
+	code := `<?php
+namespace App\Service;
+
+class MyService
+{
+    public function doWork(): void {}
+    private function helper(): void {}
+}
+
+function freeFunction(): void {}`
+	content := []byte(code)
+
+	p := sitter.NewParser()
+	lang := sitter.NewLanguage(php.LanguagePHP())
+	_ = p.SetLanguage(lang)
+	tree := p.Parse(content, nil)
+	defer tree.Close()
+
+	engine := &mockEngine{}
+	v := NewVisitor(content, engine)
+	v.Walk(tree.RootNode())
+
+	methods := engine.declaredMethods["App\\Service\\MyService"]
+	if len(methods) != 2 {
+		t.Fatalf("expected 2 declared methods for MyService, got %v", methods)
+	}
+	found := map[string]bool{}
+	for _, m := range methods {
+		found[m] = true
+	}
+	if !found["doWork"] || !found["helper"] {
+		t.Errorf("expected doWork and helper declared, got %v", methods)
+	}
+
+	for class, methods := range engine.declaredMethods {
+		for _, m := range methods {
+			if m == "freeFunction" {
+				t.Errorf("free function must not be recorded as a declared method (class=%q)", class)
+			}
+		}
 	}
 }

--- a/internal/analyzer/visitor_test.go
+++ b/internal/analyzer/visitor_test.go
@@ -1090,7 +1090,7 @@ class SuperService {
 
 	engine := &mockEngine{
 		methodReturnTypes: map[string]string{
-			"App\\Tracing\\TracerInterface::makeSpan":  "OpenTelemetry\\API\\Trace\\Span",
+        "App\\Tracing\\TracerInterface::makeSpan": "OpenTelemetry\\API\\Trace\\Span",
 			"App\\Service\\SomeSharedService::getSelf": "App\\Service\\SomeSharedService",
 		},
 	}

--- a/internal/analyzer/visitor_test.go
+++ b/internal/analyzer/visitor_test.go
@@ -760,6 +760,44 @@ class CachingHttpClient {
 	}
 }
 
+func TestPHPVisitor_RecordsCallGraphEdgeForSafeNamespaceCaller(t *testing.T) {
+	code := `<?php
+namespace App;
+
+class SafeCaller {
+    private TargetService $target;
+
+    public function run() {
+        $this->target->mutate();
+    }
+}`
+	content := []byte(code)
+
+	p := sitter.NewParser()
+	lang := sitter.NewLanguage(php.LanguagePHP())
+	_ = p.SetLanguage(lang)
+	tree := p.Parse(content, nil)
+	defer tree.Close()
+
+	engine := &mockSafeNamespaceEngine{
+		safeNamespace: "App\\SafeCaller",
+	}
+	v := NewVisitor(content, engine)
+	v.Walk(tree.RootNode())
+
+	if findings := v.Findings(); len(findings) > 0 {
+		t.Errorf("expected 0 findings inside safe namespace caller, got %d: %v", len(findings), findings)
+	}
+
+	want := "App\\SafeCaller::run -> App\\TargetService::mutate"
+	for _, call := range engine.recordedCalls {
+		if call == want {
+			return
+		}
+	}
+	t.Errorf("expected recordedCalls to contain %q, got %v", want, engine.recordedCalls)
+}
+
 func TestPHPVisitor_StaticMutationAndDependencies(t *testing.T) {
 	code := `<?php
 class MyStaticService {
@@ -778,7 +816,7 @@ class MyStaticService {
 
 	engine := &mockEngine{}
 	v := NewVisitor(content, engine)
-	
+
 	// Test SetDependencies
 	deps := []string{"App\\SomeDependency"}
 	v.SetDependencies(deps)
@@ -835,7 +873,7 @@ class AdvancedService {
 
 	engine := &mockEngine{}
 	v := NewVisitor(content, engine)
-	
+
 	var classNode *sitter.Node
 	for i := uint(0); i < tree.RootNode().ChildCount(); i++ {
 		child := tree.RootNode().Child(i)
@@ -1036,7 +1074,7 @@ class SuperService {
 
 	engine := &mockEngine{
 		methodReturnTypes: map[string]string{
-			"App\\Tracing\\TracerInterface::makeSpan": "OpenTelemetry\\API\\Trace\\Span",
+			"App\\Tracing\\TracerInterface::makeSpan":  "OpenTelemetry\\API\\Trace\\Span",
 			"App\\Service\\SomeSharedService::getSelf": "App\\Service\\SomeSharedService",
 		},
 	}

--- a/internal/auditor/auditor.go
+++ b/internal/auditor/auditor.go
@@ -127,40 +127,44 @@ func (a *Auditor) MarkReachability(results []symbol.AuditStatus) {
 
 	reachableNodes := make(map[string]bool)
 	var queue []string
-	for callerKey := range graph {
-		callerClass, _, found := strings.Cut(callerKey, "::")
-		if found && projectClasses[callerClass] && !reachableNodes[callerKey] {
-			reachableNodes[callerKey] = true
-			queue = append(queue, callerKey)
-		}
-	}
-	for len(queue) > 0 {
-		node := queue[0]
-		queue = queue[1:]
-		for callee := range graph[node] {
-			if !reachableNodes[callee] {
-				reachableNodes[callee] = true
-				queue = append(queue, callee)
-			}
+	enqueue := func(node string) {
+		if !reachableNodes[node] {
+			reachableNodes[node] = true
+			queue = append(queue, node)
 		}
 	}
 
-	// Conservative inherited-method promotion: a reachable call on a class that
-	// doesn't declare the called method itself (i.e. it inherits it, directly or
-	// through multiple `extends` levels) also marks the declaring ancestor's own
-	// method as reachable. A class that overrides the method stops the walk at
-	// itself, so an override never promotes its own reachability onto the parent.
-	reachableSnapshot := make([]string, 0, len(reachableNodes))
-	for node := range reachableNodes {
-		reachableSnapshot = append(reachableSnapshot, node)
+	for callerKey := range graph {
+		callerClass, _, found := strings.Cut(callerKey, "::")
+		if found && projectClasses[callerClass] {
+			enqueue(callerKey)
+		}
 	}
-	for _, node := range reachableSnapshot {
+
+	// Fixed-point worklist over both call-graph edges and inherited-method
+	// promotion. A reachable call on a class that doesn't declare the called
+	// method itself (i.e. it inherits it, directly or through multiple
+	// `extends` levels) also marks the declaring ancestor's own method as
+	// reachable. A class that overrides the method stops the walk at itself,
+	// so an override never promotes its own reachability onto the parent.
+	// Promoted ancestor nodes are enqueued just like any other newly reachable
+	// node, so their own outgoing call-graph edges (e.g. an inherited method
+	// calling a sibling method via `$this->`) are followed in turn. The loop
+	// only terminates once a pass adds nothing new, i.e. the queue drains.
+	for len(queue) > 0 {
+		node := queue[0]
+		queue = queue[1:]
+
+		for callee := range graph[node] {
+			enqueue(callee)
+		}
+
 		class, method, found := strings.Cut(node, "::")
 		if !found {
 			continue
 		}
 		if ancestor := a.resolveDeclaringAncestor(class, method); ancestor != "" && ancestor != class {
-			reachableNodes[ancestor+"::"+method] = true
+			enqueue(ancestor + "::" + method)
 		}
 	}
 

--- a/internal/auditor/auditor.go
+++ b/internal/auditor/auditor.go
@@ -22,6 +22,8 @@ type Auditor struct {
 	NonSharedServices    analyzer.NonSharedServiceMap
 	AuditedClasses       map[string]bool
 	methodSignatureCache map[string]map[string]string
+	callGraph            map[string]map[string]bool
+	projectClasses       map[string]bool
 	mu                   sync.Mutex
 }
 
@@ -31,6 +33,83 @@ func NewAuditor(cfg config.Config) *Auditor {
 		Config:               cfg,
 		AuditedClasses:       make(map[string]bool),
 		methodSignatureCache: make(map[string]map[string]string),
+		callGraph:            make(map[string]map[string]bool),
+		projectClasses:       make(map[string]bool),
+	}
+}
+
+type fileEngine struct {
+	*Auditor
+	isVendor bool
+}
+
+func (f *fileEngine) RecordClassAudited(name string) {
+	f.Auditor.RecordClassAudited(name)
+	if !f.isVendor {
+		f.Auditor.recordProjectClass(name)
+	}
+}
+
+func (a *Auditor) recordProjectClass(name string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.projectClasses[normalizeClassName(name)] = true
+}
+
+func (a *Auditor) RecordMethodCall(callerClass, callerMethod, calleeClass, calleeMethod string) {
+	if callerMethod == "" || calleeMethod == "" {
+		return
+	}
+	callerKey := normalizeClassName(callerClass) + "::" + callerMethod
+	calleeKey := normalizeClassName(calleeClass) + "::" + calleeMethod
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.callGraph[callerKey] == nil {
+		a.callGraph[callerKey] = make(map[string]bool)
+	}
+	a.callGraph[callerKey][calleeKey] = true
+}
+
+func (a *Auditor) MarkReachability(results []symbol.AuditStatus) {
+	a.mu.Lock()
+	graph := a.callGraph
+	projectClasses := a.projectClasses
+	a.mu.Unlock()
+
+	reachableNodes := make(map[string]bool)
+	var queue []string
+	for callerKey := range graph {
+		callerClass, _, found := strings.Cut(callerKey, "::")
+		if found && projectClasses[callerClass] && !reachableNodes[callerKey] {
+			reachableNodes[callerKey] = true
+			queue = append(queue, callerKey)
+		}
+	}
+	for len(queue) > 0 {
+		node := queue[0]
+		queue = queue[1:]
+		for callee := range graph[node] {
+			if !reachableNodes[callee] {
+				reachableNodes[callee] = true
+				queue = append(queue, callee)
+			}
+		}
+	}
+
+	for i := range results {
+		for j := range results[i].Findings {
+			finding := &results[i].Findings[j]
+			if finding.ContextClass == "" || finding.ContextMethod == "" {
+				continue
+			}
+			findingKey := normalizeClassName(finding.ContextClass) + "::" + finding.ContextMethod
+			if reachableNodes[findingKey] {
+				finding.Reachability = "HIGH"
+			} else {
+				finding.Reachability = "INFO"
+			}
+		}
 	}
 }
 
@@ -53,12 +132,25 @@ func (a *Auditor) Audit(path string, dependencies []string) ([]symbol.Finding, e
 	}
 	defer tree.Close()
 
-	v := analyzer.NewVisitor(content, a)
+	v := analyzer.NewVisitor(content, &fileEngine{Auditor: a, isVendor: isVendorPath(path)})
 	v.SetDependencies(dependencies)
 	v.SetNonSharedServices(a.NonSharedServices)
 	v.Walk(tree.RootNode())
 
 	return v.Findings(), nil
+}
+
+func isVendorPath(path string) bool {
+	p := filepath.ToSlash(path)
+	if strings.Contains(p, "/vendor/") || strings.HasPrefix(p, "vendor/") {
+		return true
+	}
+	if abs, err := filepath.Abs(path); err == nil {
+		if strings.Contains(filepath.ToSlash(abs), "/vendor/") {
+			return true
+		}
+	}
+	return false
 }
 
 // ExtractFQCN extracts the full class name from a file.

--- a/internal/auditor/auditor.go
+++ b/internal/auditor/auditor.go
@@ -132,7 +132,10 @@ func (a *Auditor) Audit(path string, dependencies []string) ([]symbol.Finding, e
 	}
 	defer tree.Close()
 
-	v := analyzer.NewVisitor(content, &fileEngine{Auditor: a, isVendor: isVendorPath(path)})
+	v := analyzer.NewVisitor(content, &fileEngine{
+		Auditor:  a,
+		isVendor: isVendorPath(a.Config.NormalizePath(path)),
+	})
 	v.SetDependencies(dependencies)
 	v.SetNonSharedServices(a.NonSharedServices)
 	v.Walk(tree.RootNode())

--- a/internal/auditor/auditor.go
+++ b/internal/auditor/auditor.go
@@ -141,16 +141,6 @@ func (a *Auditor) MarkReachability(results []symbol.AuditStatus) {
 		}
 	}
 
-	// Fixed-point worklist over both call-graph edges and inherited-method
-	// promotion. A reachable call on a class that doesn't declare the called
-	// method itself (i.e. it inherits it, directly or through multiple
-	// `extends` levels) also marks the declaring ancestor's own method as
-	// reachable. A class that overrides the method stops the walk at itself,
-	// so an override never promotes its own reachability onto the parent.
-	// Promoted ancestor nodes are enqueued just like any other newly reachable
-	// node, so their own outgoing call-graph edges (e.g. an inherited method
-	// calling a sibling method via `$this->`) are followed in turn. The loop
-	// only terminates once a pass adds nothing new, i.e. the queue drains.
 	for len(queue) > 0 {
 		node := queue[0]
 		queue = queue[1:]

--- a/internal/auditor/auditor.go
+++ b/internal/auditor/auditor.go
@@ -24,6 +24,8 @@ type Auditor struct {
 	methodSignatureCache map[string]map[string]string
 	callGraph            map[string]map[string]bool
 	projectClasses       map[string]bool
+	classParents         map[string]string
+	declaredMethods      map[string]map[string]bool
 	mu                   sync.Mutex
 }
 
@@ -35,6 +37,8 @@ func NewAuditor(cfg config.Config) *Auditor {
 		methodSignatureCache: make(map[string]map[string]string),
 		callGraph:            make(map[string]map[string]bool),
 		projectClasses:       make(map[string]bool),
+		classParents:         make(map[string]string),
+		declaredMethods:      make(map[string]map[string]bool),
 	}
 }
 
@@ -71,6 +75,50 @@ func (a *Auditor) RecordMethodCall(callerClass, callerMethod, calleeClass, calle
 	a.callGraph[callerKey][calleeKey] = true
 }
 
+// RecordClassParent records a direct `extends` relationship (childClass extends
+// parentClass), used to conservatively promote reachability to inherited methods.
+func (a *Auditor) RecordClassParent(className, parentClassName string) {
+	if className == "" || parentClassName == "" {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.classParents[normalizeClassName(className)] = normalizeClassName(parentClassName)
+}
+
+// RecordMethodDeclared records that methodName has its own declaration (body) on
+// className, distinguishing an override from an inherited, un-overridden method.
+func (a *Auditor) RecordMethodDeclared(className, methodName string) {
+	if className == "" || methodName == "" {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	key := normalizeClassName(className)
+	if a.declaredMethods[key] == nil {
+		a.declaredMethods[key] = make(map[string]bool)
+	}
+	a.declaredMethods[key][methodName] = true
+}
+
+// resolveDeclaringAncestor walks the direct-`extends` parent chain starting at
+// class, looking for the nearest ancestor (including class itself) that
+// directly declares methodName. It stops as soon as it finds a declaration —
+// so an override on a subclass is never skipped in favor of a grandparent's
+// declaration — and guards against cycles in a malformed hierarchy. Returns
+// "" if no class in the chain declares the method.
+func (a *Auditor) resolveDeclaringAncestor(class, method string) string {
+	visited := make(map[string]bool)
+	for class != "" && !visited[class] {
+		if a.declaredMethods[class][method] {
+			return class
+		}
+		visited[class] = true
+		class = a.classParents[class]
+	}
+	return ""
+}
+
 func (a *Auditor) MarkReachability(results []symbol.AuditStatus) {
 	a.mu.Lock()
 	graph := a.callGraph
@@ -94,6 +142,25 @@ func (a *Auditor) MarkReachability(results []symbol.AuditStatus) {
 				reachableNodes[callee] = true
 				queue = append(queue, callee)
 			}
+		}
+	}
+
+	// Conservative inherited-method promotion: a reachable call on a class that
+	// doesn't declare the called method itself (i.e. it inherits it, directly or
+	// through multiple `extends` levels) also marks the declaring ancestor's own
+	// method as reachable. A class that overrides the method stops the walk at
+	// itself, so an override never promotes its own reachability onto the parent.
+	reachableSnapshot := make([]string, 0, len(reachableNodes))
+	for node := range reachableNodes {
+		reachableSnapshot = append(reachableSnapshot, node)
+	}
+	for _, node := range reachableSnapshot {
+		class, method, found := strings.Cut(node, "::")
+		if !found {
+			continue
+		}
+		if ancestor := a.resolveDeclaringAncestor(class, method); ancestor != "" && ancestor != class {
+			reachableNodes[ancestor+"::"+method] = true
 		}
 	}
 

--- a/internal/auditor/reachability_test.go
+++ b/internal/auditor/reachability_test.go
@@ -93,6 +93,15 @@ func TestMarkReachability_InheritedMethodPromotedToHigh(t *testing.T) {
 		// declaration must NOT inherit that reachability.
 		{"Vendor\\Lib\\OverriddenBaseService::mutate", "INFO"},
 		{"Vendor\\Lib\\OverridingChildService::mutate", "HIGH"},
+		// Fixed-point regression: app code only calls the 3-level-deep
+		// GeneratorLeafService::getOutputFromHtml(), which promotes to ancestor
+		// method A (GeneratorBaseService::getOutputFromHtml). A's own
+		// `$this->createTemporaryFile()` call graph edge must then be followed
+		// from the newly promoted node, marking ancestor method B
+		// (GeneratorBaseService::createTemporaryFile()) reachable too — not just
+		// the directly promoted method.
+		{"Vendor\\Lib\\GeneratorBaseService::getOutputFromHtml", "HIGH"},
+		{"Vendor\\Lib\\GeneratorBaseService::createTemporaryFile", "HIGH"},
 	}
 	for _, tc := range cases {
 		if got := rankByClassMethod[tc.key]; got != tc.want {

--- a/internal/auditor/reachability_test.go
+++ b/internal/auditor/reachability_test.go
@@ -50,6 +50,97 @@ func TestMarkReachability(t *testing.T) {
 	}
 }
 
+func TestMarkReachability_InheritedMethodPromotedToHigh(t *testing.T) {
+	cfg := config.Config{}
+	auditor := NewAuditor(cfg)
+
+	appPath := filepath.Join("..", "..", "test", "fixtures", "reachability_inheritance_app.php")
+	vendorPath := filepath.Join("..", "..", "test", "fixtures", "reachability_inheritance_vendor.php")
+
+	appFindings, err := auditor.Audit(appPath, nil)
+	if err != nil {
+		t.Fatalf("failed to audit app fixture: %v", err)
+	}
+	vendorFindings, err := auditor.Audit(vendorPath, nil)
+	if err != nil {
+		t.Fatalf("failed to audit vendor fixture: %v", err)
+	}
+	auditor.recordProjectClass("App\\Controller\\InheritanceController")
+
+	results := []symbol.AuditStatus{
+		{FilePath: appPath, Findings: appFindings},
+		{FilePath: vendorPath, Findings: vendorFindings},
+	}
+
+	auditor.MarkReachability(results)
+
+	rankByClassMethod := make(map[string]string)
+	for _, f := range results[1].Findings {
+		rankByClassMethod[f.ContextClass+"::"+f.ContextMethod] = f.Reachability
+	}
+
+	cases := []struct {
+		key  string
+		want string
+	}{
+		// Inherited (not overridden) method: promoted to HIGH through a direct
+		// extends (InheritedChildService) and a multi-level extends
+		// (InheritedGrandchildService -> InheritedChildService -> InheritedBaseService).
+		{"Vendor\\Lib\\InheritedBaseService::mutate", "HIGH"},
+		// Never invoked anywhere, directly or through a subclass.
+		{"Vendor\\Lib\\InheritedBaseService::neverCalled", "INFO"},
+		// Overridden: only the child's own mutate() is called, so the parent's
+		// declaration must NOT inherit that reachability.
+		{"Vendor\\Lib\\OverriddenBaseService::mutate", "INFO"},
+		{"Vendor\\Lib\\OverridingChildService::mutate", "HIGH"},
+	}
+	for _, tc := range cases {
+		if got := rankByClassMethod[tc.key]; got != tc.want {
+			t.Errorf("expected %s to be %s, got %q (all: %v)", tc.key, tc.want, got, rankByClassMethod)
+		}
+	}
+}
+
+func TestResolveDeclaringAncestor(t *testing.T) {
+	auditor := NewAuditor(config.Config{})
+	auditor.RecordClassParent("App\\Child", "App\\Parent")
+	auditor.RecordClassParent("App\\Grandchild", "App\\Child")
+	auditor.RecordMethodDeclared("App\\Parent", "mutate")
+	auditor.RecordMethodDeclared("App\\Child", "override")
+
+	tests := []struct {
+		name   string
+		class  string
+		method string
+		want   string
+	}{
+		{"direct child inherits from parent", "App\\Child", "mutate", "App\\Parent"},
+		{"multi-level grandchild inherits from parent", "App\\Grandchild", "mutate", "App\\Parent"},
+		{"override stops at the declaring child", "App\\Grandchild", "override", "App\\Child"},
+		{"class declaring its own method resolves to itself", "App\\Parent", "mutate", "App\\Parent"},
+		{"unknown method resolves to nothing", "App\\Child", "unknown", ""},
+		{"unknown class resolves to nothing", "App\\Unrelated", "mutate", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := auditor.resolveDeclaringAncestor(tt.class, tt.method); got != tt.want {
+				t.Errorf("resolveDeclaringAncestor(%q, %q) = %q, want %q", tt.class, tt.method, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveDeclaringAncestor_CycleGuard(t *testing.T) {
+	auditor := NewAuditor(config.Config{})
+	// A malformed/self-referential hierarchy must not hang the walk.
+	auditor.RecordClassParent("App\\A", "App\\B")
+	auditor.RecordClassParent("App\\B", "App\\A")
+
+	if got := auditor.resolveDeclaringAncestor("App\\A", "mutate"); got != "" {
+		t.Errorf("expected empty result for a cyclic hierarchy with no declaration, got %q", got)
+	}
+}
+
 func TestAudit_SymlinkedVendorFileIsNotProjectClass(t *testing.T) {
 	realDir := t.TempDir()
 	phpFile := filepath.Join(realDir, "SymlinkedService.php")

--- a/internal/auditor/reachability_test.go
+++ b/internal/auditor/reachability_test.go
@@ -1,6 +1,7 @@
 package auditor
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -46,5 +47,39 @@ func TestMarkReachability(t *testing.T) {
 	}
 	if rankByMethod["neverCalled"] != "INFO" {
 		t.Errorf("expected VendorService::neverCalled() to be INFO (no call site), got %q", rankByMethod["neverCalled"])
+	}
+}
+
+func TestAudit_SymlinkedVendorFileIsNotProjectClass(t *testing.T) {
+	realDir := t.TempDir()
+	phpFile := filepath.Join(realDir, "SymlinkedService.php")
+	content := []byte(`<?php
+namespace Vendor\Lib;
+
+class SymlinkedService
+{
+    private array $data = [];
+
+    public function mutate(string $value): void
+    {
+        $this->data[] = $value;
+    }
+}
+`)
+	if err := os.WriteFile(phpFile, content, 0o644); err != nil {
+		t.Fatalf("failed to write fixture: %v", err)
+	}
+
+	auditor := NewAuditor(config.Config{
+		SymlinkMap: map[string]string{
+			realDir: "vendor/acme/symlinked-package",
+		},
+	})
+	if _, err := auditor.Audit(phpFile, nil); err != nil {
+		t.Fatalf("audit failed: %v", err)
+	}
+
+	if auditor.projectClasses["Vendor\\Lib\\SymlinkedService"] {
+		t.Error("expected symlinked vendor class to be excluded from projectClasses")
 	}
 }

--- a/internal/auditor/reachability_test.go
+++ b/internal/auditor/reachability_test.go
@@ -1,0 +1,50 @@
+package auditor
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/igor-php/igor-php/internal/config"
+	"github.com/igor-php/igor-php/pkg/symbol"
+)
+
+func TestMarkReachability(t *testing.T) {
+	cfg := config.Config{}
+	auditor := NewAuditor(cfg)
+
+	appPath := filepath.Join("..", "..", "test", "fixtures", "reachability_app.php")
+	vendorPath := filepath.Join("..", "..", "test", "fixtures", "reachability_vendor.php")
+
+	appFindings, err := auditor.Audit(appPath, nil)
+	if err != nil {
+		t.Fatalf("failed to audit app fixture: %v", err)
+	}
+	vendorFindings, err := auditor.Audit(vendorPath, nil)
+	if err != nil {
+		t.Fatalf("failed to audit vendor fixture: %v", err)
+	}
+	auditor.recordProjectClass("App\\Controller\\AppController")
+
+	if len(vendorFindings) != 2 {
+		t.Fatalf("expected 2 findings in vendor fixture (mutate + neverCalled), got %d: %+v", len(vendorFindings), vendorFindings)
+	}
+
+	results := []symbol.AuditStatus{
+		{FilePath: appPath, Findings: appFindings},
+		{FilePath: vendorPath, Findings: vendorFindings},
+	}
+
+	auditor.MarkReachability(results)
+
+	rankByMethod := make(map[string]string)
+	for _, f := range results[1].Findings {
+		rankByMethod[f.ContextMethod] = f.Reachability
+	}
+
+	if rankByMethod["mutate"] != "HIGH" {
+		t.Errorf("expected VendorService::mutate() to be HIGH (reachable via AppController::run -> entryPoint -> mutate), got %q", rankByMethod["mutate"])
+	}
+	if rankByMethod["neverCalled"] != "INFO" {
+		t.Errorf("expected VendorService::neverCalled() to be INFO (no call site), got %q", rankByMethod["neverCalled"])
+	}
+}

--- a/internal/auditor/reachability_test.go
+++ b/internal/auditor/reachability_test.go
@@ -93,13 +93,6 @@ func TestMarkReachability_InheritedMethodPromotedToHigh(t *testing.T) {
 		// declaration must NOT inherit that reachability.
 		{"Vendor\\Lib\\OverriddenBaseService::mutate", "INFO"},
 		{"Vendor\\Lib\\OverridingChildService::mutate", "HIGH"},
-		// Fixed-point regression: app code only calls the 3-level-deep
-		// GeneratorLeafService::getOutputFromHtml(), which promotes to ancestor
-		// method A (GeneratorBaseService::getOutputFromHtml). A's own
-		// `$this->createTemporaryFile()` call graph edge must then be followed
-		// from the newly promoted node, marking ancestor method B
-		// (GeneratorBaseService::createTemporaryFile()) reachable too — not just
-		// the directly promoted method.
 		{"Vendor\\Lib\\GeneratorBaseService::getOutputFromHtml", "HIGH"},
 		{"Vendor\\Lib\\GeneratorBaseService::createTemporaryFile", "HIGH"},
 	}

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -110,7 +111,13 @@ func (r *CLIReporter) PrintFindings(res symbol.AuditStatus, projectRoot string, 
 		fmt.Printf("   \033[90mService: %s\033[0m\n", res.ServiceID)
 	}
 
-	for _, f := range res.Findings {
+	findings := make([]symbol.Finding, len(res.Findings))
+	copy(findings, res.Findings)
+	sort.SliceStable(findings, func(i, j int) bool {
+		return findings[i].Reachability == "HIGH" && findings[j].Reachability != "HIGH"
+	})
+
+	for _, f := range findings {
 		severity := "error"
 		color := "\033[31m" // Red for Error
 		if f.Severity == "WARNING" {
@@ -124,8 +131,16 @@ func (r *CLIReporter) PrintFindings(res symbol.AuditStatus, projectRoot string, 
 			sourceIndicator = "\033[33m[VENDOR]\033[0m"
 		}
 
+		rankTag := ""
+		switch f.Reachability {
+		case "HIGH":
+			rankTag = " \033[1;31m[HIGH]\033[0m"
+		case "INFO":
+			rankTag = " \033[90m[INFO]\033[0m"
+		}
+
 		// Standard CLI output
-		fmt.Printf("  %s %s%s\033[0m\n", sourceIndicator, color, f.Message)
+		fmt.Printf("  %s%s %s%s\033[0m\n", sourceIndicator, rankTag, color, f.Message)
 		fmt.Printf("  \033[90m%d | %s\033[0m\n", f.Line, strings.TrimSpace(f.Code))
 
 		if f.Remediation != "" {

--- a/pkg/symbol/models.go
+++ b/pkg/symbol/models.go
@@ -7,17 +7,17 @@ import (
 
 // Finding represents a single issue detected by the linter.
 type Finding struct {
-	Message      string   `json:"message"`
-	Code         string   `json:"code"`
-	Snippet      string   `json:"snippet"`
-	Remediation  string   `json:"remediation"`
-	Severity     string   `json:"severity"` // "ERROR" or "WARNING"
-	Line         int      `json:"line"`
-	ASTDetails   string   `json:"ast_details"`
-	Dependencies []string `json:"dependencies"`
-	ContextClass  string `json:"context_class,omitempty"`
-	ContextMethod string `json:"context_method,omitempty"`
-	Reachability  string `json:"reachability,omitempty"`
+	Message       string   `json:"message"`
+	Code          string   `json:"code"`
+	Snippet       string   `json:"snippet"`
+	Remediation   string   `json:"remediation"`
+	Severity      string   `json:"severity"` // "ERROR" or "WARNING"
+	Line          int      `json:"line"`
+	ASTDetails    string   `json:"ast_details"`
+	Dependencies  []string `json:"dependencies"`
+	ContextClass  string   `json:"context_class,omitempty"`
+	ContextMethod string   `json:"context_method,omitempty"`
+	Reachability  string   `json:"reachability,omitempty"`
 }
 
 // Result groups findings by file.

--- a/pkg/symbol/models.go
+++ b/pkg/symbol/models.go
@@ -15,6 +15,9 @@ type Finding struct {
 	Line         int      `json:"line"`
 	ASTDetails   string   `json:"ast_details"`
 	Dependencies []string `json:"dependencies"`
+	ContextClass  string `json:"context_class,omitempty"`
+	ContextMethod string `json:"context_method,omitempty"`
+	Reachability  string `json:"reachability,omitempty"`
 }
 
 // Result groups findings by file.

--- a/test/fixtures/reachability_app.php
+++ b/test/fixtures/reachability_app.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Controller;
+
+use Vendor\Lib\VendorService;
+
+class AppController
+{
+    private VendorService $vendorService;
+
+    public function run(): void
+    {
+        $this->vendorService->entryPoint('hello');
+    }
+}

--- a/test/fixtures/reachability_inheritance_app.php
+++ b/test/fixtures/reachability_inheritance_app.php
@@ -5,17 +5,20 @@ namespace App\Controller;
 use Vendor\Lib\InheritedChildService;
 use Vendor\Lib\InheritedGrandchildService;
 use Vendor\Lib\OverridingChildService;
+use Vendor\Lib\GeneratorLeafService;
 
 class InheritanceController
 {
     private InheritedChildService $inheritedChildService;
     private InheritedGrandchildService $inheritedGrandchildService;
     private OverridingChildService $overridingChildService;
+    private GeneratorLeafService $generatorLeafService;
 
     public function run(): void
     {
         $this->inheritedChildService->mutate('a');
         $this->inheritedGrandchildService->mutate('b');
         $this->overridingChildService->mutate('c');
+        $this->generatorLeafService->getOutputFromHtml('<p>x</p>');
     }
 }

--- a/test/fixtures/reachability_inheritance_app.php
+++ b/test/fixtures/reachability_inheritance_app.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Controller;
+
+use Vendor\Lib\InheritedChildService;
+use Vendor\Lib\InheritedGrandchildService;
+use Vendor\Lib\OverridingChildService;
+
+class InheritanceController
+{
+    private InheritedChildService $inheritedChildService;
+    private InheritedGrandchildService $inheritedGrandchildService;
+    private OverridingChildService $overridingChildService;
+
+    public function run(): void
+    {
+        $this->inheritedChildService->mutate('a');
+        $this->inheritedGrandchildService->mutate('b');
+        $this->overridingChildService->mutate('c');
+    }
+}

--- a/test/fixtures/reachability_inheritance_vendor.php
+++ b/test/fixtures/reachability_inheritance_vendor.php
@@ -46,3 +46,35 @@ class OverridingChildService extends OverriddenBaseService
         $this->ownData[] = $value;
     }
 }
+
+class GeneratorBaseService
+{
+    private array $temporaryFiles = [];
+    private array $renderCache = [];
+
+    public function getOutputFromHtml(string $html): string
+    {
+        $this->renderCache[] = $html;
+        return $this->createTemporaryFile();
+    }
+
+    public function createTemporaryFile(): string
+    {
+        $this->temporaryFiles[] = 'tmp';
+        return 'tmp';
+    }
+}
+
+class GeneratorMiddleService extends GeneratorBaseService
+{
+    // Inherits getOutputFromHtml() and createTemporaryFile() without overriding either.
+}
+
+class GeneratorLeafService extends GeneratorMiddleService
+{
+    // Third inheritance level: still does not override anything. Only
+    // getOutputFromHtml() is called directly from app code; promoting it to
+    // GeneratorBaseService must also make the graph edge to
+    // createTemporaryFile() (reached only via `$this->` on the ancestor)
+    // reachable in turn.
+}

--- a/test/fixtures/reachability_inheritance_vendor.php
+++ b/test/fixtures/reachability_inheritance_vendor.php
@@ -67,14 +67,8 @@ class GeneratorBaseService
 
 class GeneratorMiddleService extends GeneratorBaseService
 {
-    // Inherits getOutputFromHtml() and createTemporaryFile() without overriding either.
 }
 
 class GeneratorLeafService extends GeneratorMiddleService
 {
-    // Third inheritance level: still does not override anything. Only
-    // getOutputFromHtml() is called directly from app code; promoting it to
-    // GeneratorBaseService must also make the graph edge to
-    // createTemporaryFile() (reached only via `$this->` on the ancestor)
-    // reachable in turn.
 }

--- a/test/fixtures/reachability_inheritance_vendor.php
+++ b/test/fixtures/reachability_inheritance_vendor.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Vendor\Lib;
+
+class InheritedBaseService
+{
+    private array $data = [];
+
+    public function mutate(string $value): void
+    {
+        $this->data[] = $value;
+    }
+
+    public function neverCalled(): void
+    {
+        $this->data[] = 'unused';
+    }
+}
+
+class InheritedChildService extends InheritedBaseService
+{
+    // Inherits mutate() and neverCalled() without overriding either.
+}
+
+class InheritedGrandchildService extends InheritedChildService
+{
+    // Multi-level inheritance: still does not override anything.
+}
+
+class OverriddenBaseService
+{
+    private array $data = [];
+
+    public function mutate(string $value): void
+    {
+        $this->data[] = $value;
+    }
+}
+
+class OverridingChildService extends OverriddenBaseService
+{
+    private array $ownData = [];
+
+    public function mutate(string $value): void
+    {
+        $this->ownData[] = $value;
+    }
+}

--- a/test/fixtures/reachability_vendor.php
+++ b/test/fixtures/reachability_vendor.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Vendor\Lib;
+
+class VendorService
+{
+    private array $data = [];
+    private array $other = [];
+
+    public function entryPoint(string $value): void
+    {
+        $this->mutate($value);
+    }
+
+    public function mutate(string $value): void
+    {
+        $this->data[] = $value;
+    }
+
+    public function neverCalled(): void
+    {
+        $this->other[] = 'x';
+    }
+}


### PR DESCRIPTION
## Context

Closes #76

All mutator findings currently have equal priority, whether the flagged method is reachable from application code or has no known call site. This makes actionable findings harder to review.

## Implementation

- `internal/analyzer/visitor.go`: records resolved method-call edges before checking whether the caller is non-shared or in a safe namespace. This ordering is intentional: those checks suppress mutation findings inside exempt callers, but must not hide their outbound calls from reachability analysis. The visitor also resolves `$this` to the current fully qualified class and adds class/method context to findings.
- `internal/auditor/auditor.go`: builds a thread-safe call graph, tracks classes from project files, normalizes symlinked paths through `Config.NormalizePath`, and marks findings `HIGH` when their exact `Class::Method` is reachable from project code. Unreachable findings receive `INFO`.
- `cmd/igor/main.go`: applies reachability ranking after auditing and before baseline handling and reporting.
- `pkg/reporter/reporter.go`: sorts `HIGH` findings first within each file and prints `[HIGH]` or `[INFO]` in the CLI output. JSON output includes the new finding fields.
- `pkg/symbol/models.go`: adds finding context and reachability fields.

The visitor change does not alter exemption behavior. Safe-namespace and non-shared callers still produce no mutation findings; their resolved calls now remain available for downstream reachability analysis.

## Direct inheritance support

Commits `0795fc8` and `f4b2676` add conservative direct inheritance handling for reachability ranking:

- The analyzer records direct PHP `extends` relationships and methods declared directly on each class.
- Reachability follows direct and multi-level inheritance chains.
- An inherited method finding is promoted from a reachable child method to the ancestor that declares it.
- Child overrides stop promotion, so a child override does not incorrectly mark the parent method as reachable.
- The reachability pass now runs to a fixed point. When an inherited ancestor method becomes reachable, the pass follows its existing call-graph edges, including same-class `$this->` calls to other ancestor methods.
- Added regression coverage for a three-level chain where `getOutputFromHtml()` reaches `createTemporaryFile()` through the promoted ancestor method.
- Interfaces, traits, static calls, and magic methods remain outside this change.

## Follow-up fixes

- `c496db1` removes redundant inheritance comments from the production and test code.
- `e6462c4` extracts method-declaration recording from `PHPVisitor.walk` to keep cyclomatic complexity within the configured lint limit. This refactor does not change inheritance behavior.

## Known limitations

- Reachability does not follow interface, trait, static-call, or magic-method dispatch.
- The analysis only records calls when it can resolve the receiver type from property types, tracked local variables, return types, or `$this`.
- Treat `[INFO]` as "no call site found *with this analysis*", not an absolute guarantee of dead code.

## Requirements

- [x] I have performed a self code-review.
- [x] I have added / updated unit and integration tests to verify my changes.
- [x] I have updated the documentation / README if applicable.
- [x] I have run local CI checks (`make ci`) and all checks passed. (`make ci` requires a local `golangci-lint` binary; Docker CI passed.)
- [x] I have performed manual tests to ensure the changes work as intended.

## Documentations

- Updated `README.md` with reachability ranking and direct inheritance behavior.

## Manual tests

- **Test Case:** Audited the reachability fixtures and generated projects with direct, transitive, safe-namespace, vendor, symlinked-vendor, inheritance, empty, malformed, and concurrent call patterns.
- **Observed Result:** Reachable vendor mutations receive `HIGH`; unreachable mutations receive `INFO`; exempt callers produce no findings while their outbound edges remain traceable; symlinked vendor classes do not become project roots; inherited ancestor methods and their transitive same-class calls receive `HIGH`.

## Validation

- `go test ./...` passes with 230 tests.
- `go test -race ./...` passes.
- `go vet ./...` passes.
- Docker CI tests and lint pass. The Docker build requires `GOFLAGS=-buildvcs=false` in this mounted worktree.
- `gofmt` and `git diff --check` pass.
- CLI JSON, LLM, baseline, and race-instrumented execution checks pass.

## Performance tests

No benchmark was added for inheritance. The fixed-point pass uses a deduplicated worklist and stops when no new call-graph node becomes reachable.