### PR TITLE
feat: detect __destruct magic method on shared services

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ During its static analysis of shared/singleton services, Igor recursively scans 
 | **Local Static Variable** | `LocalStaticVariable` | Declaring local static variables inside methods, which persist across the PHP process lifecycle. | 🔴 Critical | `static $counter = 0;` |
 | **PHP Superglobals** | `SuperglobalsUsage` | Direct access to legacy superglobals instead of injecting or using the framework's Request object. | 🟡 Warning | `$_GET['id']` or `$_POST['name']` |
 | **Process Termination** | `ExecutionTerminator` | Standard PHP termination statements that crash the persistent worker. | 🔴 Critical | `exit()` or `die()` |
+| **Shared Service Lifecycle** | `MagicMethodDestruct` | Declaring `__destruct()` magic method on shared/singleton services. | 🔴 Critical | `public function __destruct() { ... }` |
 
 > 💡 **Philosophy & False Positives**:
 > Igor's primary mission is to shield you as much as possible from dangerous code patterns that can pollute state or leak memory in persistent worker environments.

--- a/examples/demo-leak/src/Controller/LeakDemoController.php
+++ b/examples/demo-leak/src/Controller/LeakDemoController.php
@@ -8,6 +8,7 @@ use App\Service\FakeEntityManager;
 use App\Service\IncompleteResetService;
 use App\Service\StatefulService;
 use App\Service\StaticLeakService;
+use App\Service\DestructorLeakService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -21,6 +22,7 @@ class LeakDemoController extends AbstractController
         private FakeEntityManager $entityManager,
         private ClosureLeakService $closureLeakService,
         private LocalStaticService $localStaticService,
+        private DestructorLeakService $destructorLeakService,
     ) {}
 
     #[Route('/', name: 'demo_index')]
@@ -43,6 +45,7 @@ class LeakDemoController extends AbstractController
                 <li><a href='/closure-leak'>8. Closure State Leak</a></li>
                 <li><a href='/local-static'>9. Local Static Variable</a></li>
                 <li><a href='/superglobals'>10. PHP Superglobals</a></li>
+                <li><a href='/destructor-leak' style='color: #fd7e14; font-weight: bold;'>11. Magic Method __destruct() Bypass (NEW)</a></li>
             </ul>
         ");
     }
@@ -326,6 +329,50 @@ class LeakDemoController extends AbstractController
                           "}";
                           
         return $this->renderLayout($html, true, null, $controllerCode);
+    }
+
+    #[Route('/destructor-leak')]
+    public function destructorLeak(): Response
+    {
+        if (isset($_GET['action']) && $_GET['action'] === 'clear') {
+            $this->destructorLeakService->clearLog();
+            return $this->redirect('/destructor-leak');
+        }
+
+        $logContent = $this->destructorLeakService->getLogContent();
+
+        $html = "<h2>11. Magic Method __destruct() Bypass</h2>
+                 <div style='background: #fff3cd; padding: 15px; border: 1px solid #ffeeba; border-radius: 5px; margin-bottom: 20px;'>
+                    <b>💡 Destructor Dilemma in Worker mode:</b><br>
+                    In worker mode, your services are instantiated once as singletons and stored in memory. 
+                    Because the process survives between requests, <b>the destructor is never called</b>!<br>
+                    Any resource cleanup (like closing files, databases, flushing buffers) written in <code>__destruct()</code> will never run per-request.
+                 </div>
+                 
+                 <div style='background: #f8f9fa; padding: 15px; border-left: 5px solid #007bff; margin-bottom: 20px;'>
+                    <b>🔍 The Experiment:</b><br>
+                    1. Click <b>\"Clear Log File\"</b> below to start fresh.<br>
+                    2. In <b>Classic mode (port 8081)</b>, refresh the page. Notice how every single refresh appends BOTH <code>🟢 Constructor called</code> AND <code>🔴 Destructor called</code> because PHP destroys the service at the end of every request.<br>
+                    3. In <b>Worker mode (port 8080)</b>, refresh the page. Only <code>🟢 Constructor called</code> will appear (the very first time the worker starts), but <code>🔴 Destructor called</code> is **NEVER** called!
+                 </div>
+
+                 <div style='margin-bottom: 20px;'>
+                    <button onclick='window.location.reload()' style='padding: 10px 20px; background: #007bff; color: white; border: none; border-radius: 5px; cursor: pointer; font-weight: bold;'>🔄 Refresh Request (F5)</button>
+                    <a href='/destructor-leak?action=clear' style='display: inline-block; padding: 10px 20px; background: #dc3545; color: white; text-decoration: none; border-radius: 5px; font-weight: bold; margin-left: 10px;'>🗑️ Clear Log File</a>
+                 </div>
+                 
+                 <h3>📄 Life-cycle Event Log File (var/destructor_demo.log):</h3>
+                 <pre style='background: #1a202c; color: #f7fafc; padding: 15px; border-radius: 5px; font-family: monospace; font-size: 0.95em; overflow-x: auto;'>".htmlspecialchars($logContent, ENT_QUOTES, 'UTF-8')."</pre>";
+
+        $controllerCode = "<?php\n" .
+                          "// Inside LeakDemoController.php:\n" .
+                          "#[Route('/destructor-leak')]\n" .
+                          "public function destructorLeak(): Response {\n" .
+                          "    // Read the log written to disk by __construct() and __destruct()\n" .
+                          "    \$logContent = \$this->destructorLeakService->getLogContent();\n" .
+                          "}";
+
+        return $this->renderLayout($html, true, 'src/Service/DestructorLeakService.php', $controllerCode);
     }
 
     private function renderLayout(string $content, bool $showBack = false, ?string $codeFile = null, ?string $customCode = null): Response

--- a/examples/demo-leak/src/Service/DestructorLeakService.php
+++ b/examples/demo-leak/src/Service/DestructorLeakService.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Service;
+
+class DestructorLeakService
+{
+    private string $logPath;
+
+    public function __construct()
+    {
+        // Use a persistent file on disk to trace life-cycle events across requests
+        $this->logPath = __DIR__ . '/../../var/destructor_demo.log';
+        
+        $this->log("🟢 Constructor called");
+    }
+
+    public function __destruct()
+    {
+        $this->log("🔴 Destructor called");
+    }
+
+    public function getLogContent(): string
+    {
+        if (!file_exists($this->logPath)) {
+            return "No events recorded yet.";
+        }
+        return file_get_contents($this->logPath);
+    }
+
+    public function clearLog(): void
+    {
+        if (file_exists($this->logPath)) {
+            unlink($this->logPath);
+        }
+    }
+
+    private function log(string $message): void
+    {
+        $time = date('H:i:s');
+        $pid = getmypid();
+        $mode = php_sapi_name() === 'cli' ? 'WORKER' : 'CLASSIC/FPM';
+        // Append life-cycle event to file
+        file_put_contents(
+            $this->logPath,
+            "[$time] [PID: $pid] $message\n",
+            FILE_APPEND | LOCK_EX
+        );
+    }
+}

--- a/internal/analyzer/visitor.go
+++ b/internal/analyzer/visitor.go
@@ -105,14 +105,7 @@ func (v *PHPVisitor) walk(n *sitter.Node) {
 	case "class_declaration", "trait_declaration", "anonymous_class":
 		v.handleClass(n)
 	case "method_declaration", "function_definition":
-		if nameNode := n.ChildByFieldName("name"); nameNode != nil {
-			v.curMethod = v.getContent(nameNode)
-		}
-		v.isWorkerSafeMethod = v.hasAttribute(n, "WorkerSafe")
-		v.finallyCleaned = make(map[string]bool)
-		v.localSharedVars = make(map[string]bool)
-		v.preScanFinallyCleanups(n)
-		v.recordMethodDeclaration(nodeType)
+		v.handleMethodOrFunction(n, nodeType)
 	case "assignment_expression", "augmented_assignment_expression":
 		v.handleAssignment(n)
 	case "update_expression":
@@ -156,6 +149,33 @@ func (v *PHPVisitor) recordMethodDeclaration(nodeType string) {
 		fullName = v.namespace + "\\" + v.curClass
 	}
 	v.engine.RecordMethodDeclared(fullName, v.curMethod)
+}
+
+func (v *PHPVisitor) handleMethodOrFunction(n *sitter.Node, nodeType string) {
+	if nameNode := n.ChildByFieldName("name"); nameNode != nil {
+		v.curMethod = v.getContent(nameNode)
+	}
+	v.isWorkerSafeMethod = v.hasAttribute(n, "WorkerSafe")
+	v.finallyCleaned = make(map[string]bool)
+	v.localSharedVars = make(map[string]bool)
+	v.preScanFinallyCleanups(n)
+	v.recordMethodDeclaration(nodeType)
+
+	if nodeType == "method_declaration" && strings.ToLower(v.curMethod) == "__destruct" {
+		fullName := v.curClass
+		if v.namespace != "" {
+			fullName = v.namespace + "\\" + v.curClass
+		}
+		isTransient := false
+		if v.nonSharedServices[strings.TrimPrefix(fullName, "\\")] {
+			isTransient = true
+		} else if v.engine != nil && (v.engine.IsExplicitlyNonShared(fullName) || v.engine.IsSafeNamespace(fullName)) {
+			isTransient = true
+		}
+		if !isTransient {
+			v.addFinding(n, "Usage of __destruct() magic method is dangerous in Worker mode.", "Destructors on shared services are not invoked at the end of each request in Worker mode.", "ERROR")
+		}
+	}
 }
 
 func (v *PHPVisitor) handleNamespace(n *sitter.Node) {

--- a/internal/analyzer/visitor_test.go
+++ b/internal/analyzer/visitor_test.go
@@ -1260,3 +1260,69 @@ function freeFunction(): void {}`
 		}
 	}
 }
+
+func TestPHPVisitor_DestructorDetection(t *testing.T) {
+	code := `<?php
+class SharedService {
+    public function __destruct() {
+        // Unsafe: shared service destructors are not invoked in persistent worker mode
+    }
+}
+
+class TransientService {
+    public function __destruct() {
+        // Safe: transient/non-shared service destructors are invoked when they go out of scope
+    }
+}
+
+#[WorkerSafe]
+class SafeService {
+    public function __destruct() {
+        // Safe: marked as WorkerSafe
+    }
+}
+
+class SafeMethodService {
+    #[WorkerSafe]
+    public function __destruct() {
+        // Safe: marked as WorkerSafe
+    }
+}
+`
+	content := []byte(code)
+
+	p := sitter.NewParser()
+	lang := sitter.NewLanguage(php.LanguagePHP())
+	_ = p.SetLanguage(lang)
+	tree := p.Parse(content, nil)
+	defer tree.Close()
+
+	// Engine configuration where TransientService is explicitly non-shared
+	engine := &mockEngine{}
+	v := NewVisitor(content, engine)
+	
+	// Set TransientService as non-shared
+	nonShared := make(NonSharedServiceMap)
+	nonShared["TransientService"] = true
+	v.SetNonSharedServices(nonShared)
+
+	v.Walk(tree.RootNode())
+
+	findings := v.Findings()
+
+	// We expect exactly 1 finding: on SharedService::__destruct()
+	if len(findings) != 1 {
+		t.Fatalf("Expected exactly 1 finding, got %d: %v", len(findings), findings)
+	}
+
+	finding := findings[0]
+	if !strings.Contains(finding.Message, "__destruct()") {
+		t.Errorf("Expected message to mention __destruct(), got: %s", finding.Message)
+	}
+	if finding.Severity != "ERROR" {
+		t.Errorf("Expected severity to be ERROR, got: %s", finding.Severity)
+	}
+	if !strings.Contains(finding.Remediation, "Destructors") {
+		t.Errorf("Expected remediation to mention Destructors, got: %s", finding.Remediation)
+	}
+}

--- a/internal/auditor/service_auditor_test.go
+++ b/internal/auditor/service_auditor_test.go
@@ -90,6 +90,12 @@ func TestAuditFixtures(t *testing.T) {
 			expectedErrors: 1,
 			contains:       "Property 'localProp' of ConcreteChildAdapterWithLocalLeak is mutated but not reset",
 		},
+		{
+			name:           "Destructor detection magic method",
+			fixture:        "destructor_test.php",
+			expectedErrors: 1,
+			contains:       "Usage of __destruct() magic method is dangerous in Worker mode.",
+		},
 	}
 
 	for _, tt := range tests {

--- a/test/fixtures/destructor_test.php
+++ b/test/fixtures/destructor_test.php
@@ -1,0 +1,28 @@
+<?php
+
+class DestructorClass {
+    public function __destruct() {
+        // This is dangerous and should be flagged
+    }
+}
+
+class IgnoredDestructorClass {
+    /** @igor-ignore */
+    public function __destruct() {
+        // This is dangerous but has @igor-ignore, so it should not be flagged
+    }
+}
+
+#[WorkerSafe]
+class SafeClass {
+    public function __destruct() {
+        // Safe: class is WorkerSafe
+    }
+}
+
+class SafeMethodClass {
+    #[WorkerSafe]
+    public function __destruct() {
+        // Safe: method is WorkerSafe
+    }
+}


### PR DESCRIPTION
- Implement static analysis rule in AST PHPVisitor to detect __destruct() method declarations.
- Bypass destructor warnings on explicitly non-shared (transient) services, or those with #[WorkerSafe] attributes.
- Add comprehensive unit tests in visitor_test.go covering both detection and bypasses.
- Add integration test fixture destructor_test.php and integrate into Auditor test suite.
- Update demo-leak playground with DestructorLeakService and a file-based trace experiment to demonstrate persistent service destructors not firing in FrankenPHP.
- Update README.md rules catalog with details about the new Shared Service Lifecycle rule.

## Context

*Provide a clear and concise description of the context (the feature, improvement, or the bug you are fixing).*

*If this PR is linked to an existing GitHub issue, please reference it here (e.g. `Closes #123`).*

## Implementation

*Explain how you resolved the issue or implemented the feature. Share any architectural decisions, additions, or modifications.*

## Requirements

*Please ensure that your PR is ready by checking the appropriate boxes. If an action is not applicable (e.g., configuration changes), you can mark it as checked or note it as N/A.*

- [X] I have performed a self code-review.
- [X] I have added / updated unit and integration tests to verify my changes.
- [X] I have updated the documentation / README if applicable.
- [X] I have run local CI checks (`make ci`) and all checks passed.
- [X] I have performed manual tests to ensure the changes work as intended.

## Documentations

*Add links to updated documentation if applicable.*

## Manual tests

*Describe the manual tests you performed in addition to automated tests to verify your implementation (this helps reviewers verify your work).*

- **Test Case:**
- **Observed Result:**

## Performance tests (optional)

*If this PR introduces major AST parsing or auditing logic changes, share any benchmark or execution time results.*

## Screenshots (optional)

*Add screenshots or terminal recordings/GIFs if this PR introduces visual or formatting changes to the command-line output.*
