### PR TITLE
feat(analyzer,auditor,cli): interface alias reachability via containe…

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,10 @@ Export your container's graph to a framework-agnostic JSON file and pass it with
     { "class": "App\\Http\\Uri", "shared": false },
     { "class": "App\\Cache\\CacheItem", "shared": false },
     { "class": "App\\Service\\MailService", "shared": true }
-  ]
+  ],
+  "aliases": {
+    "App\\Contract\\MailerInterface": "App\\Service\\MailService"
+  }
 }
 ```
 
@@ -258,7 +261,7 @@ Export your container's graph to a framework-agnostic JSON file and pass it with
 igor-php --no-agent --container-dump igor-container.json .
 ```
 
-By convention, keep `igor-container.json` at the project root, side-by-side with `igor.json`. Any class listed with `"shared": false` is treated as transient and its state mutations are **skipped** — exactly as the Symfony bridge already skips non-shared (prototype) services. Classes marked `"shared": true`, or absent from the file, continue to be audited normally. You can also set the path in `igor.json` via `"container_dump": "igor-container.json"`.
+By convention, keep `igor-container.json` at the project root, side-by-side with `igor.json`. Any class listed with `"shared": false` is treated as transient and its state mutations are **skipped** — exactly as the Symfony bridge already skips non-shared (prototype) services. Classes marked `"shared": true`, or absent from the file, continue to be audited normally. The optional `"aliases"` map tells Igor which interface FQCN resolves to which concrete class, so reachability ranking can follow calls made through an interface type-hint. You can also set the path in `igor.json` via `"container_dump": "igor-container.json"`.
 
 > 💡 The format is intentionally minimal so **any** framework can produce it (Laravel, Laminas, …). Symfony's `igor_service_map.json` is simply one richer producer of the same idea.
 >
@@ -366,7 +369,7 @@ Not every flagged mutator matters equally: a setter on a vendor class might neve
   275 | $this->binary = $binary;
 ```
 
-> 💡 **Known limitation**: reachability matching works on exact `Class::Method` pairs. Igor conservatively follows direct and multi-level `extends` chains — a subclass that inherits, but doesn't override, a flagged parent method is linked through to the parent's finding, and an override correctly stops that promotion at the overriding class. It does **not** follow interfaces, traits, or magic methods (`__call`, `__get`, etc.), so a call resolved only through one of those still won't be linked through. Treat `[INFO]` as "no call site found *with this analysis*", not an absolute guarantee of dead code.
+> 💡 **Known limitation**: reachability matching works on exact `Class::Method` pairs. Igor conservatively follows direct and multi-level `extends` chains — a subclass that inherits, but doesn't override, a flagged parent method is linked through to the parent's finding, and an override correctly stops that promotion at the overriding class. It also follows interface aliases from the Symfony agent map or `--container-dump`, so a call through an interface type-hint is linked to the concrete implementation. It does **not** follow traits or magic methods (`__call`, `__get`, etc.), so a call resolved only through one of those still won't be linked through. Treat `[INFO]` as "no call site found *with this analysis*", not an absolute guarantee of dead code.
 
 ---
 
@@ -395,7 +398,7 @@ You can customize Igor's behavior by creating an `igor.json` file at the root of
 - **ignore_vendors**: Set to `true` to skip auditing all services located within the `vendor/` directory. Defaults to `false`.
 - **baseline**: Path to a baseline file containing findings to ignore.
 - **ignore_external_baseline**: Set to `true` to skip discovering and merging baseline files from external vendor packages. Defaults to `false`.
-- **container_dump**: Path to a generic container dump JSON (`{ "services": [ { "class": ..., "shared": bool } ] }`) listing non-shared/transient classes to skip. Equivalent to the `--container-dump` flag.
+- **container_dump**: Path to a generic container dump JSON (`{ "services": [ { "class": ..., "shared": bool } ], "aliases": { "Interface": "ConcreteClass" } }`) listing non-shared/transient classes to skip and optional interface-to-implementation aliases for reachability. Equivalent to the `--container-dump` flag.
 - **console_path**: Custom path to the Symfony console binary. Defaults to `bin/console`.
 - **env**: Symfony environment to use for container analysis. Defaults to `dev`.
 - **verbose**: Enable verbose output to see skipped services and reasons. Defaults to `false`.

--- a/cmd/igor/audit.go
+++ b/cmd/igor/audit.go
@@ -40,9 +40,9 @@ func calculateAuditStatus(findings []symbol.Finding) string {
 	return "⚠️  WARN"
 }
 
-func loadContainerDump(rootPath string, cfg config.Config) analyzer.NonSharedServiceMap {
+func loadContainerDump(rootPath string, cfg config.Config) (analyzer.NonSharedServiceMap, analyzer.AliasesMap) {
 	if cfg.ContainerDump == "" {
-		return nil
+		return nil, nil
 	}
 
 	dumpPath := cfg.ContainerDump
@@ -50,14 +50,17 @@ func loadContainerDump(rootPath string, cfg config.Config) analyzer.NonSharedSer
 		dumpPath = filepath.Join(rootPath, dumpPath)
 	}
 
-	nonShared, err := analyzer.LoadContainerDump(dumpPath)
+	nonShared, aliases, err := analyzer.LoadContainerDump(dumpPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "⚠️  Warning: Could not load container dump from %s: %v\n", dumpPath, err)
-		return nil
+		return nil, nil
 	}
 
 	fmt.Fprintf(os.Stderr, "📦 Container dump loaded: %d non-shared (transient) classes will be skipped.\n", len(nonShared))
-	return nonShared
+	if len(aliases) > 0 {
+		fmt.Fprintf(os.Stderr, "   %d interface aliases will be used for reachability.\n", len(aliases))
+	}
+	return nonShared, aliases
 }
 
 func runParallelAudit(auditList []symbol.AuditStatus, aud *auditor.Auditor) <-chan symbol.AuditStatus {

--- a/cmd/igor/main.go
+++ b/cmd/igor/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/igor-php/igor-php/internal/analyzer"
 	"github.com/igor-php/igor-php/internal/auditor"
 	"github.com/igor-php/igor-php/internal/config"
 )
@@ -27,7 +28,8 @@ func main() {
 	rep := setupReporter(cfg)
 
 	// 1b. Load generic container dump (non-shared/transient classes to skip)
-	aud.NonSharedServices = loadContainerDump(rootPath, cfg)
+	var containerAliases analyzer.AliasesMap
+	aud.NonSharedServices, containerAliases = loadContainerDump(rootPath, cfg)
 
 	// 2. Detect Symfony project
 	symfony, err := detectSymfonyProject(rootPath, cfg)
@@ -36,6 +38,12 @@ func main() {
 		os.Exit(1)
 	}
 	aud.Symfony = symfony
+	if aud.Symfony != nil {
+		aud.LoadSymfonyAliases()
+	}
+	if len(containerAliases) > 0 {
+		aud.LoadInterfaceAliases(containerAliases)
+	}
 
 	// 3. Load Baseline
 	baseline := loadAuditBaseline(rootPath, &cfg)

--- a/cmd/igor/main_refactored_test.go
+++ b/cmd/igor/main_refactored_test.go
@@ -52,16 +52,16 @@ func TestCalculateAuditStatus(t *testing.T) {
 func TestLoadContainerDump(t *testing.T) {
 	// Case 1: Empty dump path
 	cfgEmpty := config.Config{ContainerDump: ""}
-	nonSharedEmpty := loadContainerDump("/root", cfgEmpty)
-	if nonSharedEmpty != nil {
-		t.Error("Expected nil container dump map for empty configuration")
+	nonSharedEmpty, aliasesEmpty := loadContainerDump("/root", cfgEmpty)
+	if nonSharedEmpty != nil || aliasesEmpty != nil {
+		t.Error("Expected nil container dump maps for empty configuration")
 	}
 
 	// Case 2: Non-existent dump path
 	cfgMissing := config.Config{ContainerDump: "missing-dump.json"}
-	nonSharedMissing := loadContainerDump("/root", cfgMissing)
-	if nonSharedMissing != nil {
-		t.Error("Expected nil container dump map for missing dump path")
+	nonSharedMissing, aliasesMissing := loadContainerDump("/root", cfgMissing)
+	if nonSharedMissing != nil || aliasesMissing != nil {
+		t.Error("Expected nil container dump maps for missing dump path")
 	}
 
 	// Case 3: Valid JSON container dump
@@ -71,19 +71,25 @@ func TestLoadContainerDump(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	dumpData := `{"services": [{"class": "App\\Service\\Transient", "shared": false}]}`
+	dumpData := `{"services": [{"class": "App\\Service\\Transient", "shared": false}], "aliases": {"App\\Contract\\CalculatorInterface": "App\\Service\\Calculator"}}`
 	dumpPath := filepath.Join(tempDir, "container-dump.json")
 	if err := os.WriteFile(dumpPath, []byte(dumpData), 0644); err != nil {
 		t.Fatalf("Failed to write dump file: %v", err)
 	}
 
 	cfgValid := config.Config{ContainerDump: dumpPath}
-	nonSharedValid := loadContainerDump(tempDir, cfgValid)
+	nonSharedValid, aliasesValid := loadContainerDump(tempDir, cfgValid)
 	if nonSharedValid == nil {
 		t.Fatal("Expected populated container dump map, got nil")
 	}
 	if !nonSharedValid["App\\Service\\Transient"] {
 		t.Error("Expected App\\Service\\Transient to be registered as non-shared")
+	}
+	if aliasesValid == nil {
+		t.Fatal("Expected populated aliases map, got nil")
+	}
+	if aliasesValid["App\\Contract\\CalculatorInterface"] != "App\\Service\\Calculator" {
+		t.Errorf("Expected interface alias to resolve to App\\Service\\Calculator, got %q", aliasesValid["App\\Contract\\CalculatorInterface"])
 	}
 }
 

--- a/internal/analyzer/container.go
+++ b/internal/analyzer/container.go
@@ -22,39 +22,45 @@ type ServiceDefinition struct {
 // `--container-dump` flag, mirroring `{ "services": [ ... ] }`.
 type ContainerDump struct {
 	Services []ServiceDefinition `json:"services"`
+	Aliases  AliasesMap          `json:"aliases"`
 }
 
 // NonSharedServiceMap acts as an O(1) lookup table for transient classes,
 // keyed by fully-qualified class name (without a leading backslash).
 type NonSharedServiceMap map[string]bool
 
+// AliasesMap maps interface FQCNs to their concrete implementation FQCNs,
+// used to refine the reachability call graph.
+type AliasesMap map[string]string
+
 // LoadContainerDump reads and decodes the JSON file, returning a populated map
-// of non-shared (transient) classes.
+// of non-shared (transient) classes and a map of interface aliases.
 //
-// An empty filePath yields an empty (non-nil) map and no error, so callers can
+// An empty filePath yields empty (non-nil) maps and no error, so callers can
 // invoke it unconditionally. Class names are normalized by trimming any leading
 // namespace separator so lookups match the visitor's resolved FQCN.
-func LoadContainerDump(filePath string) (NonSharedServiceMap, error) {
+func LoadContainerDump(filePath string) (NonSharedServiceMap, AliasesMap, error) {
 	nonSharedMap := make(NonSharedServiceMap)
+	aliases := make(AliasesMap)
 
 	if filePath == "" {
-		return nonSharedMap, nil
+		return nonSharedMap, aliases, nil
 	}
 
 	file, err := os.Open(filePath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer func() { _ = file.Close() }()
 
 	bytes, err := io.ReadAll(file)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var dump ContainerDump
 	if err := json.Unmarshal(bytes, &dump); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	for _, service := range dump.Services {
@@ -67,5 +73,14 @@ func LoadContainerDump(filePath string) (NonSharedServiceMap, error) {
 		}
 	}
 
-	return nonSharedMap, nil
+	for interfaceName, target := range dump.Aliases {
+		interfaceName = strings.TrimPrefix(interfaceName, "\\")
+		target = strings.TrimPrefix(target, "\\")
+		if interfaceName == "" || target == "" {
+			continue
+		}
+		aliases[interfaceName] = target
+	}
+
+	return nonSharedMap, aliases, nil
 }

--- a/internal/analyzer/container_test.go
+++ b/internal/analyzer/container_test.go
@@ -28,7 +28,7 @@ func TestLoadContainerDumpValidatesSuccessfully(t *testing.T) {
 	}
 	_ = tempFile.Close()
 
-	nonShared, err := LoadContainerDump(tempFile.Name())
+	nonShared, aliases, err := LoadContainerDump(tempFile.Name())
 	if err != nil {
 		t.Fatalf("Unexpected parsing error: %v", err)
 	}
@@ -40,27 +40,82 @@ func TestLoadContainerDumpValidatesSuccessfully(t *testing.T) {
 	if nonShared["App\\Security\\Security"] {
 		t.Error("Security is a shared service and should not exist in the non-shared lookup map")
 	}
+
+	if len(aliases) != 0 {
+		t.Errorf("Expected no aliases, got %d", len(aliases))
+	}
 }
 
 // TestLoadContainerDumpEmptyPath guarantees callers can invoke the loader
 // unconditionally: an empty path yields an empty, non-nil map and no error.
 func TestLoadContainerDumpEmptyPath(t *testing.T) {
-	nonShared, err := LoadContainerDump("")
+	nonShared, aliases, err := LoadContainerDump("")
 	if err != nil {
 		t.Fatalf("Unexpected error for empty path: %v", err)
 	}
 	if nonShared == nil {
 		t.Fatal("Expected a non-nil map for empty path")
 	}
+	if aliases == nil {
+		t.Fatal("Expected a non-nil aliases map for empty path")
+	}
 	if len(nonShared) != 0 {
 		t.Errorf("Expected an empty map for empty path, got %d entries", len(nonShared))
+	}
+	if len(aliases) != 0 {
+		t.Errorf("Expected an empty aliases map for empty path, got %d entries", len(aliases))
+	}
+}
+
+// TestLoadContainerDumpParsesAliases ensures interface-to-implementation
+// aliases are loaded and normalized from the JSON dump.
+func TestLoadContainerDumpParsesAliases(t *testing.T) {
+	tempFile, err := os.CreateTemp("", "container_aliases_*.json")
+	if err != nil {
+		t.Fatalf("Failed to create temporary file: %v", err)
+	}
+	defer func() { _ = os.Remove(tempFile.Name()) }()
+
+    content := `{
+        "services": [
+            {"class": "App\\Service\\MailService", "shared": true},
+            {"class": "App\\Service\\Logger", "shared": true}
+        ],
+        "aliases": {
+            "App\\Contract\\MailerInterface": "App\\Service\\MailService",
+            "\\App\\Contract\\LoggerInterface": "App\\Service\\Logger",
+            "App\\Contract\\FactoryInterface": "app.factory"
+        }
+    }`
+
+	if _, err := tempFile.Write([]byte(content)); err != nil {
+		t.Fatalf("Failed to write mock JSON content: %v", err)
+	}
+	_ = tempFile.Close()
+
+	_, aliases, err := LoadContainerDump(tempFile.Name())
+	if err != nil {
+		t.Fatalf("Unexpected parsing error: %v", err)
+	}
+
+	if len(aliases) != 3 {
+		t.Fatalf("Expected 3 aliases, got %d", len(aliases))
+	}
+	if aliases["App\\Contract\\MailerInterface"] != "App\\Service\\MailService" {
+		t.Errorf("Expected MailerInterface -> MailService, got %q", aliases["App\\Contract\\MailerInterface"])
+	}
+	if aliases["App\\Contract\\LoggerInterface"] != "App\\Service\\Logger" {
+		t.Errorf("Expected LoggerInterface -> Logger, got %q", aliases["App\\Contract\\LoggerInterface"])
+	}
+	if aliases["App\\Contract\\FactoryInterface"] != "app.factory" {
+		t.Errorf("Expected FactoryInterface -> app.factory, got %q", aliases["App\\Contract\\FactoryInterface"])
 	}
 }
 
 // TestLoadContainerDumpMissingFile ensures a missing file surfaces as an error
 // rather than silently succeeding.
 func TestLoadContainerDumpMissingFile(t *testing.T) {
-	_, err := LoadContainerDump(filepath.Join(t.TempDir(), "does-not-exist.json"))
+	_, _, err := LoadContainerDump(filepath.Join(t.TempDir(), "does-not-exist.json"))
 	if err == nil {
 		t.Fatal("Expected an error for a missing container dump file, got nil")
 	}
@@ -81,13 +136,16 @@ func TestLoadContainerDumpNormalizesLeadingBackslash(t *testing.T) {
 	}
 	_ = tempFile.Close()
 
-	nonShared, err := LoadContainerDump(tempFile.Name())
+	nonShared, aliases, err := LoadContainerDump(tempFile.Name())
 	if err != nil {
 		t.Fatalf("Unexpected parsing error: %v", err)
 	}
 
 	if !nonShared["App\\Http\\Stream"] {
 		t.Error("Stream should be matched after trimming the leading backslash")
+	}
+	if len(aliases) != 0 {
+		t.Errorf("Expected no aliases, got %d", len(aliases))
 	}
 }
 

--- a/internal/auditor/auditor.go
+++ b/internal/auditor/auditor.go
@@ -20,6 +20,7 @@ type Auditor struct {
 	Config               config.Config
 	Symfony              *SymfonyBridge
 	NonSharedServices    analyzer.NonSharedServiceMap
+	InterfaceAliases     analyzer.AliasesMap
 	AuditedClasses       map[string]bool
 	methodSignatureCache map[string]map[string]string
 	callGraph            map[string]map[string]bool
@@ -40,6 +41,75 @@ func NewAuditor(cfg config.Config) *Auditor {
 		classParents:         make(map[string]string),
 		declaredMethods:      make(map[string]map[string]bool),
 	}
+}
+
+// LoadInterfaceAliases normalizes raw interface-to-target mappings and stores
+// them as interface FQCN -> concrete class FQCN. When a Symfony container is
+// available, service IDs and alias chains are resolved to their concrete class.
+func (a *Auditor) LoadInterfaceAliases(raw analyzer.AliasesMap) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.InterfaceAliases == nil {
+		a.InterfaceAliases = make(analyzer.AliasesMap)
+	}
+
+	for iface, target := range raw {
+		iface = normalizeClassName(iface)
+		target = normalizeClassName(target)
+		if iface == "" || target == "" {
+			continue
+		}
+		a.InterfaceAliases[iface] = a.resolveAliasToConcrete(target)
+	}
+}
+
+// LoadSymfonyAliases converts the Symfony container alias map into the unified
+// interface alias map used by reachability ranking.
+func (a *Auditor) LoadSymfonyAliases() {
+	if a.Symfony == nil || a.Symfony.Container == nil {
+		return
+	}
+
+	raw := make(analyzer.AliasesMap)
+	for aliasKey, val := range a.Symfony.Container.Aliases {
+		if target := resolveAliasTarget(val); target != "" {
+			raw[aliasKey] = target
+		}
+	}
+	a.LoadInterfaceAliases(raw)
+}
+
+// resolveInterfaceClass returns the concrete class for an interface FQCN when
+// an alias is known. It returns an empty string when no mapping exists.
+func (a *Auditor) resolveInterfaceClass(className string) string {
+	if concrete, ok := a.InterfaceAliases[normalizeClassName(className)]; ok {
+		return concrete
+	}
+	return ""
+}
+
+// resolveAliasToConcrete follows Symfony aliases and definitions until it
+// reaches a concrete class. For non-Symfony projects it returns the target as-is.
+func (a *Auditor) resolveAliasToConcrete(target string) string {
+	if a.Symfony == nil || a.Symfony.Container == nil {
+		return target
+	}
+
+	possibleIDs := a.resolveAliases(target)
+	for _, id := range possibleIDs {
+		for defID, def := range a.Symfony.Container.Definitions {
+			normDefID := normalizeClassName(defID)
+			normDefClass := normalizeClassName(def.Class)
+			if id == normDefID || id == normDefClass {
+				if def.Class != "" {
+					return normDefClass
+				}
+				return normDefID
+			}
+		}
+	}
+	return target
 }
 
 type fileEngine struct {
@@ -152,6 +222,9 @@ func (a *Auditor) MarkReachability(results []symbol.AuditStatus) {
 		class, method, found := strings.Cut(node, "::")
 		if !found {
 			continue
+		}
+		if concrete := a.resolveInterfaceClass(class); concrete != "" && concrete != class {
+			enqueue(concrete + "::" + method)
 		}
 		if ancestor := a.resolveDeclaringAncestor(class, method); ancestor != "" && ancestor != class {
 			enqueue(ancestor + "::" + method)

--- a/internal/auditor/reachability_test.go
+++ b/internal/auditor/reachability_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/igor-php/igor-php/internal/analyzer"
 	"github.com/igor-php/igor-php/internal/config"
 	"github.com/igor-php/igor-php/pkg/symbol"
 )
@@ -100,6 +101,65 @@ func TestMarkReachability_InheritedMethodPromotedToHigh(t *testing.T) {
 		if got := rankByClassMethod[tc.key]; got != tc.want {
 			t.Errorf("expected %s to be %s, got %q (all: %v)", tc.key, tc.want, got, rankByClassMethod)
 		}
+	}
+}
+
+func TestMarkReachability_InterfaceCallPromotedToHigh(t *testing.T) {
+	appPath := filepath.Join("..", "..", "test", "fixtures", "reachability_interface_app.php")
+	vendorPath := filepath.Join("..", "..", "test", "fixtures", "reachability_interface_vendor.php")
+
+	cases := []struct {
+		name    string
+		aliases analyzer.AliasesMap
+		want    map[string]string
+	}{
+		{
+			name:    "without interface aliases concrete method is unreachable",
+			aliases: nil,
+			want:    map[string]string{"add": "INFO", "neverCalled": "INFO"},
+		},
+		{
+			name: "with interface aliases call resolves to concrete class",
+			aliases: analyzer.AliasesMap{
+				"Vendor\\Lib\\CalculatorInterface": "Vendor\\Lib\\Calculator",
+			},
+			want: map[string]string{"add": "HIGH", "neverCalled": "INFO"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			auditor := NewAuditor(config.Config{})
+
+			appFindings, err := auditor.Audit(appPath, nil)
+			if err != nil {
+				t.Fatalf("failed to audit app fixture: %v", err)
+			}
+			vendorFindings, err := auditor.Audit(vendorPath, nil)
+			if err != nil {
+				t.Fatalf("failed to audit vendor fixture: %v", err)
+			}
+
+			auditor.recordProjectClass("App\\Controller\\InterfaceController")
+			auditor.LoadInterfaceAliases(tc.aliases)
+
+			results := []symbol.AuditStatus{
+				{FilePath: appPath, Findings: appFindings},
+				{FilePath: vendorPath, Findings: vendorFindings},
+			}
+			auditor.MarkReachability(results)
+
+			rankByMethod := make(map[string]string)
+			for _, f := range results[1].Findings {
+				rankByMethod[f.ContextMethod] = f.Reachability
+			}
+
+			for method, wantRank := range tc.want {
+				if got := rankByMethod[method]; got != wantRank {
+					t.Errorf("expected Calculator::%s() to be %s, got %q", method, wantRank, got)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/auditor/service_auditor_test.go
+++ b/internal/auditor/service_auditor_test.go
@@ -313,6 +313,43 @@ func TestAuditor_IsResettable_DoctrineManager(t *testing.T) {
 	}
 }
 
+func TestAuditor_ResolveAliasToConcrete(t *testing.T) {
+	a := NewAuditor(config.Config{})
+	a.Symfony = &SymfonyBridge{
+		Container: &symbol.SymfonyContainer{
+			Definitions: map[string]symbol.SymfonyService{
+				"app.factory": {
+					Class:  "App\\Service\\Factory",
+					Shared: true,
+				},
+				"App\\Service\\Direct": {
+					Class:  "App\\Service\\Direct",
+					Shared: true,
+				},
+			},
+		},
+	}
+
+	t.Run("resolves service id alias to concrete class", func(t *testing.T) {
+		if got := a.resolveAliasToConcrete("app.factory"); got != "App\\Service\\Factory" {
+			t.Errorf("Expected app.factory -> App\\Service\\Factory, got %q", got)
+		}
+	})
+
+	t.Run("returns class fqcn when target is already a class", func(t *testing.T) {
+		if got := a.resolveAliasToConcrete("App\\Service\\Direct"); got != "App\\Service\\Direct" {
+			t.Errorf("Expected direct class to stay unchanged, got %q", got)
+		}
+	})
+
+	t.Run("returns target as-is when no symfony container is loaded", func(t *testing.T) {
+		a2 := NewAuditor(config.Config{})
+		if got := a2.resolveAliasToConcrete("App\\Service\\NoContainer"); got != "App\\Service\\NoContainer" {
+			t.Errorf("Expected target unchanged without container, got %q", got)
+		}
+	})
+}
+
 func TestAuditor_GetMethodReturnType(t *testing.T) {
 	// Create temporary directory for our test file
 	tmpDir, err := os.MkdirTemp("", "igor_auditor_test")

--- a/test/fixtures/reachability_interface_app.php
+++ b/test/fixtures/reachability_interface_app.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Controller;
+
+use Vendor\Lib\CalculatorInterface;
+
+class InterfaceController
+{
+    public function __construct(private CalculatorInterface $calculator)
+    {
+    }
+
+    public function run(): void
+    {
+        $this->calculator->add(1);
+    }
+}

--- a/test/fixtures/reachability_interface_vendor.php
+++ b/test/fixtures/reachability_interface_vendor.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Vendor\Lib;
+
+interface CalculatorInterface
+{
+    public function add(int $value): void;
+}
+
+class Calculator implements CalculatorInterface
+{
+    private int $total = 0;
+
+    public function add(int $value): void
+    {
+        $this->total += $value;
+    }
+
+    public function neverCalled(): void
+    {
+        $this->total = 0;
+    }
+}


### PR DESCRIPTION
## Context

Closes #79.

Reachability ranking currently cannot follow calls made through interface type-hints. When a controller depends on `MailerInterface`, the concrete `MailService::mutate()` stays `INFO` even though it is reachable.

## Implementation

- `internal/analyzer/container.go`: added `AliasesMap` and parsed the optional `aliases` field from `--container-dump`.
- `internal/auditor/auditor.go`: loaded Symfony agent aliases into `InterfaceAliases`; resolved interface call sites to concrete classes during reachability BFS, including service-id aliases.
- `cmd/igor/main.go`: wired Symfony and container-dump aliases into the auditor.
- Added fixtures and tests for class-to-class, service-id, and end-to-end reachability promotion.
- Updated `README.md` with the `aliases` field and revised the known-limitation note.

## Requirements

- [x] I have performed a self code-review.
- [x] I have added / updated unit and integration tests to verify my changes.
- [x] I have updated the documentation / README if applicable.
- [x] I have run local CI checks (`go build ./... && go test ./...`) and all checks passed.
- [x] I have performed manual tests to ensure the changes work as intended.

## Documentations

- Updated `README.md` with the `--container-dump` aliases example and description.

## Manual tests

- Ran `go test ./...`.
- Verified `Calculator::add()` promotes from `INFO` to `HIGH` when the interface alias is loaded.
- Verified `LoadContainerDump` parses class and service-id aliases, including leading-backslash normalization.

## Validation

- `go build ./...` passes.
- `go test ./...` passes.
- `go vet ./...` passes.
- `gofmt` and `git diff --check` pass.
